### PR TITLE
DEV: Make login a base-class default on Authenticator.get_handlers.

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -12,6 +12,7 @@ import simplepam
 from IPython.config import LoggingConfigurable
 from IPython.utils.traitlets import Bool, Set, Unicode
 
+from .handlers.login import LoginHandler
 from .utils import url_path_join
 
 class Authenticator(LoggingConfigurable):
@@ -70,7 +71,9 @@ class Authenticator(LoggingConfigurable):
         
         (e.g. for OAuth)
         """
-        return []
+        return [
+            ('/login', LoginHandler),
+        ]
 
 class LocalAuthenticator(Authenticator):
     """Base class for Authenticators that work with local *ix users

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -69,7 +69,8 @@ class LoginHandler(BaseHandler):
             )
             self.finish(html)
 
+
+# Only logout is a default handler.
 default_handlers = [
-    (r"/login", LoginHandler),
     (r"/logout", LogoutHandler),
 ]


### PR DESCRIPTION
Rather than a module-level default.  This prevents `/login` from sticking around when another Authenticator replaces the login handler.