### PR TITLE
add JupyterHub.admin_access

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -321,6 +321,12 @@ class JupyterHub(Application):
     db = Any()
     session_factory = Any()
     
+    admin_access = Bool(False, config=True,
+        help="""Grant admin users permission to access single-user servers.
+        
+        Users should be properly informed if this is enabled.
+        """
+    )
     admin_users = Set(config=True,
         help="""set of usernames of admin users
 
@@ -708,6 +714,7 @@ class JupyterHub(Application):
             proxy=self.proxy,
             hub=self.hub,
             admin_users=self.admin_users,
+            admin_access=self.admin_access,
             authenticator=self.authenticator,
             spawner_class=self.spawner_class,
             base_url=self.base_url,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -244,6 +244,7 @@ class BaseHandler(RequestHandler):
         user = self.get_current_user()
         return dict(
             base_url=self.hub.server.base_url,
+            prefix=self.base_url,
             user=user,
             login_url=self.settings['login_url'],
             logout_url=self.settings['logout_url'],

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -127,23 +127,31 @@ class BaseHandler(RequestHandler):
         if user and user.server:
             self.clear_cookie(user.server.cookie_name, path=user.server.base_url)
         self.clear_cookie(self.hub.server.cookie_name, path=self.hub.server.base_url)
-
+    
+    def set_server_cookie(self, user):
+        """set the login cookie for the single-user server"""
+        self.set_secure_cookie(
+            user.server.cookie_name,
+            user.cookie_id,
+            path=user.server.base_url,
+        )
+    
+    def set_hub_cookie(self, user):
+        """set the login cookie for the Hub"""
+        self.set_secure_cookie(
+            self.hub.server.cookie_name,
+            user.cookie_id,
+            path=self.hub.server.base_url)
+    
     def set_login_cookie(self, user):
         """Set login cookies for the Hub and single-user server."""
         # create and set a new cookie token for the single-user server
         if user.server:
-            self.set_secure_cookie(
-                user.server.cookie_name,
-                user.cookie_id,
-                path=user.server.base_url,
-            )
+            self.set_server_cookie(user)
         
         # create and set a new cookie token for the hub
         if not self.get_current_user_cookie():
-            self.set_secure_cookie(
-                self.hub.server.cookie_name,
-                user.cookie_id,
-                path=self.hub.server.base_url)
+            self.set_hub_cookie(user)
     
     @gen.coroutine
     def authenticate(self, data):

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -48,6 +48,7 @@ class AdminHandler(BaseHandler):
         html = self.render_template('admin.html',
             user=self.get_current_user(),
             users=self.db.query(orm.User),
+            admin_access=self.settings.get('admin_access', False),
         )
         self.finish(html)
 

--- a/share/jupyter/hub/static/js/admin.js
+++ b/share/jupyter/hub/static/js/admin.js
@@ -1,10 +1,12 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-require(["jquery", "bootstrap", "moment", "jhapi"], function ($, bs, moment, JHAPI) {
+require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, moment, JHAPI, utils) {
     "use strict";
     
     var base_url = window.jhdata.base_url;
+    var prefix = window.jhdata.prefix;
+    
     var api = new JHAPI(base_url);
     
     var get_row = function (element) {
@@ -31,7 +33,24 @@ require(["jquery", "bootstrap", "moment", "jhapi"], function ($, bs, moment, JHA
             }
         });
     });
-
+    
+    $(".access-server").click(function () {
+        var el = $(this);
+        var row = get_row(el);
+        var user = row.data('user');
+        var w = window.open();
+        api.admin_access(user, {
+            async: false,
+            success: function () {
+                w.location = utils.url_path_join(prefix, 'user', user);
+            },
+            error: function (xhr, err) {
+                w.close();
+                console.error("Failed to gain access to server", err);
+            }
+        });
+    });
+    
     $(".start-server").click(function () {
         var el = $(this);
         var row = get_row(el);

--- a/share/jupyter/hub/static/js/jhapi.js
+++ b/share/jupyter/hub/static/js/jhapi.js
@@ -100,6 +100,19 @@ define(['jquery', 'utils'], function ($, utils) {
         );
     };
     
+    JHAPI.prototype.admin_access = function (user, options) {
+        options = options || {};
+        options = update(options, {
+            type: 'POST',
+            dataType: null,
+        });
+        
+        this.api_request(
+            utils.url_path_join('users', user, 'admin-access'),
+            options
+        );
+    };
+    
     JHAPI.prototype.delete_user = function (user, options) {
         options = options || {};
         options = update(options, {type: 'DELETE', dataType: null});

--- a/share/jupyter/hub/templates/admin.html
+++ b/share/jupyter/hub/templates/admin.html
@@ -15,10 +15,13 @@
     <tr class="user-row" data-user="{{u.name}}" data-admin="{{u.admin}}">
       <td class="name-col col-sm-2">{{u.name}}</td>
       <td class="admin-col col-sm-2">{% if u.admin %}admin{% endif %}</td>
-      <td class="time-col col-sm-4">{{u.last_activity.isoformat() + 'Z'}}</td>
-      <td class="server-col col-sm-2 text-center">
+      <td class="time-col col-sm-3">{{u.last_activity.isoformat() + 'Z'}}</td>
+      <td class="server-col col-sm-3 text-center">
       {% if u.server %}
         <span class="stop-server btn btn-xs btn-danger">stop server</span>
+        {% if admin_access %}
+        <span class="access-server btn btn-xs btn-success">access server</span>
+        {% endif %}
       {% else %}
         <span class="start-server btn btn-xs btn-success">start server</span>
       {% endif %}

--- a/share/jupyter/hub/templates/page.html
+++ b/share/jupyter/hub/templates/page.html
@@ -54,6 +54,7 @@
     <script type="text/javascript">
       window.jhdata = {
         base_url: "{{base_url}}",
+        prefix: "{{prefix}}",
         {% if user %}
         user: "{{user.name}}",
         {% endif %}


### PR DESCRIPTION
optionally allow admin users to login to user servers by visiting a special admin-only URL that sets the relevant cookie

- disabled by default
- an 'access server' button is added to the admin panel, which sets the necessary cookie to log in to a given user server, one at a time
- each admin access is logged at warning-level, logging to admin user and the target user

ping @jhamrick