### PR TITLE
more info in log prefix

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -338,11 +338,11 @@ class JupyterHub(Application):
     
     def _log_datefmt_default(self):
         """Exclude date from default date format"""
-        return "%H:%M:%S"
+        return "%Y-%m-%d %H:%M:%S"
 
     def _log_format_default(self):
         """override default log format to include time"""
-        return "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s]%(end_color)s %(message)s"
+        return "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s %(module)s:%(lineno)d]%(end_color)s %(message)s"
 
     def init_logging(self):
         # This prevents double log messages because tornado use a root logger that

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -112,6 +112,8 @@ aliases.update({
 class SingleUserNotebookApp(NotebookApp):
     """A Subclass of the regular NotebookApp that is aware of the parent multiuser context."""
     user = Unicode(config=True)
+    def _user_changed(self, name, old, new):
+        self.log.name = new
     cookie_name = Unicode(config=True)
     hub_prefix = Unicode(config=True)
     hub_api_url = Unicode(config=True)
@@ -120,6 +122,14 @@ class SingleUserNotebookApp(NotebookApp):
     login_handler_class = JupyterHubLoginHandler
     logout_handler_class = JupyterHubLogoutHandler
     
+    def _log_datefmt_default(self):
+        """Exclude date from default date format"""
+        return "%Y-%m-%d %H:%M:%S"
+
+    def _log_format_default(self):
+        """override default log format to include time"""
+        return "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s %(module)s:%(lineno)d]%(end_color)s %(message)s"
+
     def _confirm_exit(self):
         # disable the exit confirmation for background notebook processes
         ioloop.IOLoop.instance().stop()


### PR DESCRIPTION
- include date, in addition to time
- show module:line
- put username in single-user log prefix

It's more information, making the log prefix pretty long now, but I think it makes sense, given the number of log sources and likely duration of a JupyterHub instance.