### PR TITLE
DEV: Allow Authenticator.add_user to not be a future.

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -548,7 +548,7 @@ class JupyterHub(Application):
         db.commit()
         
         for user in new_users:
-            yield self.authenticator.add_user(user)
+            yield gen.maybe_future(self.authenticator.add_user(user))
         db.commit()
         
         user_summaries = ['']


### PR DESCRIPTION
In particular, this fixes an error that occurs if a user subclasses the base Authenticator class and doesn't override add_user.