### PR TITLE
Logo links to Hub home instead of user URL

### DIFF
--- a/share/jupyter/hub/templates/page.html
+++ b/share/jupyter/hub/templates/page.html
@@ -89,6 +89,7 @@
     <span id="login_widget">
       {% if user %}
         <a id="logout" class="btn navbar-btn btn-default pull-right" href="{{logout_url}}">Logout</a>
+        <a id="hub-home" class="btn navbar-btn btn-default pull-right" href="{{base_url}}">Hub</a>
       {% else %}
         <a id="login" class="btn navbar-btn btn-default pull-right" href="{{login_url}}">Login</a>
       {% endif %}

--- a/share/jupyter/hub/templates/page.html
+++ b/share/jupyter/hub/templates/page.html
@@ -82,14 +82,13 @@
 
 <div id="header" class="navbar navbar-static-top">
   <div class="container">
-  <span id="jupyterhub-logo" class="pull-left"><a href="{{base_url}}" alt='dashboard'><img src='{{static_url("images/jupyterhub-80.png") }}' alt='JupyterHub' class='jpy-logo'/></a></span>
+  <span id="jupyterhub-logo" class="pull-left"><a href="{{prefix}}" alt='dashboard'><img src='{{static_url("images/jupyterhub-80.png") }}' alt='JupyterHub' class='jpy-logo'/></a></span>
 
   {% block login_widget %}
 
     <span id="login_widget">
       {% if user %}
         <a id="logout" class="btn navbar-btn btn-default pull-right" href="{{logout_url}}">Logout</a>
-        <a id="hub-home" class="btn navbar-btn btn-default pull-right" href="{{base_url}}">Hub</a>
       {% else %}
         <a id="login" class="btn navbar-btn btn-default pull-right" href="{{login_url}}">Login</a>
       {% endif %}


### PR DESCRIPTION
Currently the Jupyter logo link brings us to the users' dashboard and there is no way to get to the initial screen (containing "Stop my server"/"My server"/"Admin" buttons)