### PR TITLE
prevent inconsistent state if Spawner.start fails

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -14,12 +14,18 @@ from .base import APIHandler
 class BaseUserHandler(APIHandler):
     
     def user_model(self, user):
-        return {
+        model = {
             'name': user.name,
             'admin': user.admin,
-            'server': user.server.base_url if user.running and not (user.spawn_pending or user.stop_pending) else None,
+            'server': user.server.base_url if user.running else None,
+            'pending': None,
             'last_activity': user.last_activity.isoformat(),
         }
+        if user.spawn_pending:
+            model['pending'] = 'spawn'
+        elif user.stop_pending:
+            model['pending'] = 'stop'
+        return model
     
     _model_types = {
         'name': str,

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -322,9 +322,9 @@ class User(Base):
         spawner.api_token = api_token
         
         self.spawn_pending = True
-        f = spawner.start()
         # wait for spawner.start to return
         try:
+            f = spawner.start()
             yield gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
         except Exception as e:
             if isinstance(e, gen.TimeoutError):

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -267,6 +267,15 @@ class User(Base):
                 name=self.name,
             )
     
+    @property
+    def running(self):
+        """property for whether a user has a running server"""
+        if self.spawner is None:
+            return False
+        if self.server is None:
+            return False
+        return True
+    
     def new_api_token(self):
         """Create a new API token"""
         assert self.id is not None

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -104,11 +104,13 @@ def test_get_users(app):
             'name': 'admin',
             'admin': True,
             'server': None,
+            'pending': None,
         },
         {
             'name': 'user',
             'admin': False,
             'server': None,
+            'pending': None,
         }
     ]
 

--- a/share/jupyter/hub/templates/admin.html
+++ b/share/jupyter/hub/templates/admin.html
@@ -42,11 +42,11 @@
       <td class="admin-col col-sm-2">{% if u.admin %}admin{% endif %}</td>
       <td class="time-col col-sm-3">{{u.last_activity.isoformat() + 'Z'}}</td>
       <td class="server-col col-sm-3 text-center">
-        <span class="stop-server btn btn-xs btn-danger {% if not u.server %}hidden{% endif %}">stop server</span>
+        <span class="stop-server btn btn-xs btn-danger {% if not u.running %}hidden{% endif %}">stop server</span>
         {% if admin_access %}
-        <span class="access-server btn btn-xs btn-success {% if not u.server %}hidden{% endif %}">access server</span>
+        <span class="access-server btn btn-xs btn-success {% if not u.running %}hidden{% endif %}">access server</span>
         {% endif %}
-        <span class="start-server btn btn-xs btn-success {% if u.server %}hidden{% endif %}">start server</span>
+        <span class="start-server btn btn-xs btn-success {% if u.running %}hidden{% endif %}">start server</span>
       </td>
       <td class="edit-col col-sm-2">
         <span class="edit-user btn btn-xs btn-primary">edit</span>

--- a/share/jupyter/hub/templates/home.html
+++ b/share/jupyter/hub/templates/home.html
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="row">
     <div class="text-center">
-      {% if user.server %}
+      {% if user.running %}
       <a id="stop" class="btn btn-lg btn-danger">Stop My Server</a>
       {% endif %}
       <a id="start" class="btn btn-lg btn-success"


### PR DESCRIPTION
cleanup after all exceptions, not just 

also add User.running property and use it everywhere, to avoid inconsistent representations of whether a server is running or not.

User.running is inclusive of pending start/stop, and the pending state is added to the user REST model.

closes #146