### PR TITLE
add proxy API

### DIFF
--- a/jupyterhub/apihandlers/__init__.py
+++ b/jupyterhub/apihandlers/__init__.py
@@ -1,9 +1,10 @@
 from .base import *
 from .auth import *
+from .proxy import *
 from .users import *
 
-from . import auth, users
+from . import auth, proxy, users
 
 default_handlers = []
-for mod in (auth, users):
+for mod in (auth, proxy, users):
     default_handlers.extend(mod.default_handlers)

--- a/jupyterhub/apihandlers/proxy.py
+++ b/jupyterhub/apihandlers/proxy.py
@@ -1,0 +1,68 @@
+"""Proxy handlers"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+
+from tornado import gen, web
+
+from .. import orm
+from ..utils import admin_only
+from .base import APIHandler
+
+class ProxyAPIHandler(APIHandler):
+    
+    @admin_only
+    @gen.coroutine
+    def get(self):
+        """GET /api/proxy fetches the routing table
+        
+        This is the same as fetching the routing table directly from the proxy,
+        but without clients needing to maintain separate
+        """
+        routes = yield self.proxy.get_routes()
+        self.write(json.dumps(routes))
+    
+    @admin_only
+    @gen.coroutine
+    def post(self):
+        """POST checks the proxy to ensure"""
+        yield self.proxy.check_routes()
+        
+    
+    @admin_only
+    @gen.coroutine
+    def patch(self):
+        """PATCH updates the location of the proxy
+        
+        Can be used to notify the Hub that a new proxy is in charge
+        """
+        if not self.request.body:
+            raise web.HTTPError(400, "need JSON body")
+        
+        try:
+            model = json.loads(self.request.body.decode('utf8', 'replace'))
+        except ValueError:
+            raise web.HTTPError(400, "Request body must be JSON dict")
+        if not isinstance(model, dict):
+            raise web.HTTPError(400, "Request body must be JSON dict")
+        
+        server = self.proxy.api_server
+        if 'ip' in model:
+            server.ip = model['ip']
+        if 'port' in model:
+            server.port = model['port']
+        if 'protocol' in model:
+            server.proto = model['protocol']
+        if 'auth_token' in model:
+            self.proxy.auth_token = model['auth_token']
+        self.db.commit()
+        self.log.info("Updated proxy at %s", server.url)
+        yield self.proxy.check_routes()
+        
+
+
+default_handlers = [
+    (r"/api/proxy", ProxyAPIHandler),
+]

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -1,4 +1,4 @@
-"""Authorization handlers"""
+"""User handlers"""
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -869,6 +869,7 @@ class JupyterHub(Application):
             user.last_activity = max(user.last_activity, dt)
 
         self.db.commit()
+        yield self.proxy.check_routes(routes)
     
     @gen.coroutine
     def start(self):

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -47,6 +47,10 @@ def io_loop():
 @fixture(scope='module')
 def app(request):
     app = MockHub.instance(log_level=logging.DEBUG)
+    print(app)
     app.start([])
-    request.addfinalizer(app.stop)
+    def fin():
+        MockHub.clear_instance()
+        app.stop()
+    request.addfinalizer(fin)
     return app

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -120,7 +120,7 @@ class MockHub(JupyterHub):
         evt.wait(timeout=5)
     
     def stop(self):
-        self.io_loop.add_callback(self.io_loop.stop)
+        super().stop()
         self._thread.join()
         IOLoop().run_sync(self.cleanup)
         # ignore the call that will fire in atexit

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -275,3 +275,10 @@ def test_never_spawn(app, io_loop):
     assert not user.spawn_pending
     status = io_loop.run_sync(user.spawner.poll)
     assert status is not None
+
+
+def test_get_proxy(app, io_loop):
+    r = api_request(app, 'proxy')
+    r.raise_for_status()
+    reply = r.json()
+    assert list(reply.keys()) == ['/']

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -1,0 +1,104 @@
+"""Test a proxy being started before the Hub"""
+
+import json
+import os
+from subprocess import Popen
+
+from .mocking import MockHub
+from .test_api import api_request
+from ..utils import wait_for_http_server
+
+def test_external_proxy(request, io_loop):
+    """Test a proxy started before the Hub"""
+    auth_token='secret!'
+    proxy_ip = '127.0.0.1'
+    proxy_port = 54321
+    
+    app = MockHub.instance(
+        proxy_api_ip=proxy_ip,
+        proxy_api_port=proxy_port,
+        proxy_auth_token=auth_token,
+    )
+    request.addfinalizer(app.stop)
+    env = os.environ.copy()
+    env['CONFIGPROXY_AUTH_TOKEN'] = auth_token
+    cmd = [app.proxy_cmd,
+        '--ip', app.ip,
+        '--port', str(app.port),
+        '--api-ip', proxy_ip,
+        '--api-port', str(proxy_port),
+        '--default-target', 'http://%s:%i' % (app.hub_ip, app.hub_port),
+    ]
+    proxy = Popen(cmd, env=env)
+    def _cleanup_proxy():
+        if proxy.poll() is None:
+            proxy.terminate()
+    request.addfinalizer(_cleanup_proxy)
+    
+    def wait_for_proxy():
+        io_loop.run_sync(lambda : wait_for_http_server(
+            'http://%s:%i' % (proxy_ip, proxy_port)))
+    wait_for_proxy()
+    
+    app.start([])
+    
+    assert app.proxy_process is None
+    
+    routes = io_loop.run_sync(app.proxy.get_routes)
+    assert list(routes.keys()) == ['/']
+    
+    # add user
+    name = 'river'
+    r = api_request(app, 'users', name, method='post')
+    r.raise_for_status()
+    r = api_request(app, 'users', name, 'server', method='post')
+    r.raise_for_status()
+    
+    routes = io_loop.run_sync(app.proxy.get_routes)
+    assert sorted(routes.keys()) == ['/', '/user/river']
+    
+    # teardown the proxy and start a new one in the same place
+    proxy.terminate()
+    proxy = Popen(cmd, env=env)
+    wait_for_proxy()
+    
+    routes = io_loop.run_sync(app.proxy.get_routes)
+    assert list(routes.keys()) == ['/']
+    
+    # poke the server to update the proxy
+    r = api_request(app, 'proxy', method='post')
+    r.raise_for_status()
+    
+    # check that the routes are correct
+    routes = io_loop.run_sync(app.proxy.get_routes)
+    assert sorted(routes.keys()) == ['/', '/user/river']
+    
+    # teardown the proxy again, and start a new one with different auth and port
+    proxy.terminate()
+    new_auth_token = 'different!'
+    env['CONFIGPROXY_AUTH_TOKEN'] = new_auth_token
+    proxy_port = 55432
+    cmd = [app.proxy_cmd,
+        '--ip', app.ip,
+        '--port', str(app.port),
+        '--api-ip', app.proxy_api_ip,
+        '--api-port', str(proxy_port),
+        '--default-target', 'http://%s:%i' % (app.hub_ip, app.hub_port),
+    ]
+    
+    proxy = Popen(cmd, env=env)
+    wait_for_proxy()
+    
+    # tell the hub where the new proxy is
+    r = api_request(app, 'proxy', method='patch', data=json.dumps({
+        'port': proxy_port,
+        'auth_token': new_auth_token,
+    }))
+    r.raise_for_status()
+    assert app.proxy.api_server.port == proxy_port
+    assert app.proxy.auth_token == new_auth_token
+    
+    # check that the routes are correct
+    routes = io_loop.run_sync(app.proxy.get_routes)
+    assert sorted(routes.keys()) == ['/', '/user/river']
+


### PR DESCRIPTION
- GET fetches proxy table (duplicate of proxy's API endpoint, but allows scripts to only have one API key)
- POST prods routing table sync (useful when proxy restarts)
- PATCH allows updating the proxy API location, auth token

This should facilitate the CHP instance being managed outside the Hub. In master, running the proxy outside the Hub allows restarting the Hub independently of the Proxy, but not restarting the Proxy independently of the Hub. The main useful addition here is that a restarted proxy can `POST /hub/api/proxy` to cause the Hub to update the proxy's routing table. If, for some reason, the proxy has to start at a new URL, a PATCH request can be used to update that information.

For sanity checking, the Hub ensures the routing table makes sense on every last_activity update (five minutes).

A test is added that exercised restarting the Proxy while the Hub is running, both at the same URL via POST and at a new location via PATCH.

/cc @jhamrick