### PR TITLE
DEV: Add support for logging to a file.

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -393,7 +393,8 @@ class JupyterHub(Application):
             datefmt=self.log_datefmt,
         )
         for handler in self.extra_log_handlers:
-            handler.setFormatter(_formatter)
+            if handler.formatter is None:
+                handler.setFormatter(_formatter)
             self.log.addHandler(handler)
 
         # hook up tornado 3's loggers to our app handlers

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -366,11 +366,19 @@ class JupyterHub(Application):
         """override default log format to include time"""
         return "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s %(module)s:%(lineno)d]%(end_color)s %(message)s"
 
-    extra_log_file = Unicode("", config=True)
+    extra_log_file = Unicode(
+        "",
+        config=True,
+        help="""Set a FileHandler on this file.
+
+        Ignored if extra_log_handler is explicitly set in config file.
+        """
+    )
     extra_log_handler = Instance(
         klass=logging.Handler,
         allow_none=True,
         config=True,
+        help="Extra handler to set on JupyterHub logger.",
     )
 
     def _extra_log_handler_default(self):


### PR DESCRIPTION
Adds an `extra_log_file` configurable to `JupyterHub`, which, if set, creates a `FileHandler` and adds it to the application logger.

Also adds support for explicitly configuring more exotic loggers via `extra_log_handler`.

I originally started trying to make this change in the core `IPython` application class, but it looks like it's tricky to do correctly there because the logging machinery is set up much earlier in the lifetime of the object.  It's easier to do here because `init_logging` is called after all the rest of the configuration has happened.