### PR TITLE
make shutdown of servers and proxy optional during Hub shutdown

### DIFF
--- a/jupyterhub/apihandlers/__init__.py
+++ b/jupyterhub/apihandlers/__init__.py
@@ -1,10 +1,11 @@
 from .base import *
 from .auth import *
+from .hub import *
 from .proxy import *
 from .users import *
 
-from . import auth, proxy, users
+from . import auth, hub, proxy, users
 
 default_handlers = []
-for mod in (auth, proxy, users):
+for mod in (auth, hub, proxy, users):
     default_handlers.extend(mod.default_handlers)

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -1,0 +1,51 @@
+"""API handlers for administering the Hub itself"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from tornado import web
+from tornado.ioloop import IOLoop
+
+from ..utils import admin_only
+from .base import APIHandler
+
+class ShutdownAPIHandler(APIHandler):
+    
+    @admin_only
+    def post(self):
+        """POST /api/shutdown triggers a clean shutdown
+        
+        URL parameters:
+        
+        - servers: specify whether single-user servers should be terminated
+        - proxy: specify whether the proxy should be terminated
+        """
+        from ..app import JupyterHub
+        app = JupyterHub.instance()
+        proxy = self.get_argument('proxy', '').lower()
+        if proxy == 'false':
+            app.cleanup_proxy = False
+        elif proxy == 'true':
+            app.cleanup_proxy = True
+        elif proxy:
+            raise web.HTTPError(400, "proxy must be true or false, got %r" % proxy)
+        servers = self.get_argument('servers', '').lower()
+        if servers == 'false':
+            app.cleanup_servers = False
+        elif servers == 'true':
+            app.cleanup_servers = True
+        elif servers:
+            raise web.HTTPError(400, "servers must be true or false, got %r" % servers)
+        
+        # finish the request
+        self.set_status(202)
+        self.finish()
+        
+        # stop the eventloop, which will trigger cleanup
+        loop = IOLoop.current()
+        loop.add_callback(loop.stop)
+
+
+default_handlers = [
+    (r"/api/shutdown", ShutdownAPIHandler),
+]

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -353,12 +353,15 @@ class JupyterHub(Application):
         
         Disable if you want to be able to teardown the Hub while leaving the single-user servers running.
         
+        If both this and cleanup_proxy are False, sending SIGINT to the Hub will
+        only shutdown the Hub, leaving everything else running.
+        
         The Hub should be able to resume from database state.
         """
     )
 
     cleanup_proxy = Bool(True, config=True,
-        help="""Whether to shutdown single-user servers when the Hub shuts down.
+        help="""Whether to shutdown the proxy when the Hub shuts down.
         
         Disable if you want to be able to teardown the Hub while leaving the proxy running.
         

--- a/share/jupyter/hub/static/js/admin.js
+++ b/share/jupyter/hub/static/js/admin.js
@@ -169,5 +169,21 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
             }
         });
     });
+
+    $("#shutdown-hub").click(function () {
+        var dialog = $("#shutdown-hub-dialog");
+        dialog.find("input[type=checkbox]").prop("checked", true);
+        dialog.modal();
+    });
+
+    $("#shutdown-hub-dialog").find(".shutdown-button").click(function () {
+        var dialog = $("#shutdown-hub-dialog");
+        var servers = dialog.find(".shutdown-servers-checkbox").prop("checked");
+        var proxy = dialog.find(".shutdown-proxy-checkbox").prop("checked");
+        api.shutdown_hub({
+            proxy: proxy,
+            servers: servers,
+        });
+    });
     
 });

--- a/share/jupyter/hub/static/js/jhapi.js
+++ b/share/jupyter/hub/static/js/jhapi.js
@@ -10,7 +10,7 @@ define(['jquery', 'utils'], function ($, utils) {
     
     var default_options = {
         type: 'GET',
-        headers: {'Content-Type': 'application/json'},
+        contentType: "application/json",
         cache: false,
         dataType : "json",
         processData: false,
@@ -120,6 +120,15 @@ define(['jquery', 'utils'], function ($, utils) {
             utils.url_path_join('users', user),
             options
         );
+    };
+    
+    JHAPI.prototype.shutdown_hub = function (data, options) {
+        options = options || {};
+        options = update(options, {type: 'POST'});
+        if (data) {
+            options.data = JSON.stringify(data);
+        }
+        this.api_request('shutdown', options);
     };
     
     return JHAPI;

--- a/share/jupyter/hub/templates/admin.html
+++ b/share/jupyter/hub/templates/admin.html
@@ -32,7 +32,8 @@
     <tbody>
       <tr class="user-row add-user-row">
         <td colspan="5">
-          <a id="add-user" class="col-xs-12 btn btn-default">Add User</a>
+          <a id="add-user" class="col-xs-5 btn btn-default">Add User</a>
+          <a id="shutdown-hub" class="col-xs-4 col-xs-offset-3 btn btn-danger">Shutdown Hub</a>
         </td>
       </tr>
   {% for u in users %}
@@ -64,6 +65,21 @@
 {% call modal('Delete User', btn_class='btn-danger delete-button') %}
   Are you sure you want to delete user <span class="delete-username">USER</span>?
   This operation cannot be undone.
+{% endcall %}
+
+{% call modal('Shutdown Hub', btn_label='Shutdown', btn_class='btn-danger shutdown-button') %}
+  Are you sure you want to shutdown the Hub?
+  You can chose to leave the proxy and/or single-user servers running by unchecking the boxes below:
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" class="shutdown-proxy-checkbox">Shutdown proxy
+    </label>
+  </div>
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" class="shutdown-servers-checkbox">Shutdown single-user-servers
+    </label>
+  </div>
 {% endcall %}
 
 {% macro user_modal(name) %}


### PR DESCRIPTION
- [x] add cleanup_servers and cleanup_proxy config
- [x] add /api/shutdown handler, which allows making the proxy/server
- [x] add button/dialog to the admin page to shutdown with the parameters

/cc @jhamrick