### PR TITLE
add IPython 3 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ipython/ipython.git#egg=ipython[notebook]
+ipython[notebook]>=3
 tornado>=4
 jinja2
 simplepam


### PR DESCRIPTION
IPython 3 is released, so no longer need git URL