### PR TITLE
make spawner IP configurable

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -65,7 +65,7 @@ class Server(Base):
     __tablename__ = 'servers'
     id = Column(Integer, primary_key=True)
     proto = Column(Unicode, default='http')
-    ip = Column(Unicode, default='localhost')
+    ip = Column(Unicode, default='')
     port = Column(Integer, default=random_port)
     base_url = Column(Unicode, default='/')
     cookie_name = Column(Unicode, default='cookie')

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -41,6 +41,9 @@ class Spawner(LoggingConfigurable):
     user = Any()
     hub = Any()
     api_token = Unicode()
+    ip = Unicode('localhost', config=True,
+        help="The IP address (or hostname) the single-user server should listen on"
+    )
     start_timeout = Integer(60, config=True,
         help="""Timeout (in seconds) before giving up on the spawner.
         
@@ -142,10 +145,11 @@ class Spawner(LoggingConfigurable):
             '--port=%i' % self.user.server.port,
             '--cookie-name=%s' % self.user.server.cookie_name,
             '--base-url=%s' % self.user.server.base_url,
-            
             '--hub-prefix=%s' % self.hub.server.base_url,
             '--hub-api-url=%s' % self.hub.api_url,
             ]
+        if self.ip:
+            args.append('--ip=%s' % self.ip)
         if self.notebook_dir:
             args.append('--notebook-dir=%s' % self.notebook_dir)
         if self.debug:
@@ -321,6 +325,8 @@ class LocalProcessSpawner(Spawner):
     @gen.coroutine
     def start(self):
         """Start the process"""
+        if self.ip:
+            self.user.server.ip = self.ip
         self.user.server.port = random_port()
         cmd = []
         env = self.env.copy()

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -22,7 +22,7 @@ def db():
     """Get a db session"""
     global _db
     if _db is None:
-        _db = orm.new_session_factory('sqlite:///:memory:', echo=True)()
+        _db = orm.new_session_factory('sqlite:///:memory:')()
         user = orm.User(
             name=getuser(),
             server=orm.Server(),

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -14,12 +14,12 @@ def test_server(db):
     server = orm.Server()
     db.add(server)
     db.commit()
-    assert server.ip == 'localhost'
+    assert server.ip == ''
     assert server.base_url == '/'
     assert server.proto == 'http'
     assert isinstance(server.port, int)
     assert isinstance(server.cookie_name, str)
-    assert server.url == 'http://localhost:%i/' % server.port
+    assert server.url == 'http://*:%i/' % server.port
 
 
 def test_proxy(db):
@@ -65,7 +65,7 @@ def test_user(db):
     db.add(user)
     db.commit()
     assert user.name == 'kaylee'
-    assert user.server.ip == 'localhost'
+    assert user.server.ip == ''
     assert user.state == {'pid': 4234}
 
     found = orm.User.find(db, 'kaylee')

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -45,6 +45,7 @@ def new_spawner(db, **kwargs):
 def test_spawner(db, io_loop):
     spawner = new_spawner(db)
     io_loop.run_sync(spawner.start)
+    assert spawner.user.server.ip == 'localhost'
     
     # wait for the process to get to the while True: loop
     time.sleep(1)


### PR DESCRIPTION
local spawners were hardcoded as 'localhost'

mainly to enable localhost->127.0.0.1 config in pathological cases