### PR TITLE
make host connectable when ip is empty

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -77,7 +77,7 @@ class Server(Base):
     def host(self):
         return "{proto}://{ip}:{port}".format(
             proto=self.proto,
-            ip=self.ip or '*',
+            ip=self.ip or 'localhost',
             port=self.port,
         )
     
@@ -92,7 +92,7 @@ class Server(Base):
     def wait_up(self, timeout=10, http=False):
         """Wait for this server to come up"""
         if http:
-            yield wait_for_http_server(self.url.replace('//*', '//localhost'), timeout=timeout)
+            yield wait_for_http_server(self.url, timeout=timeout)
         else:
             yield wait_for_server(self.ip or 'localhost', self.port, timeout=timeout)
     

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -19,7 +19,11 @@ def test_server(db):
     assert server.proto == 'http'
     assert isinstance(server.port, int)
     assert isinstance(server.cookie_name, str)
-    assert server.url == 'http://*:%i/' % server.port
+    assert server.host == 'http://localhost:%i' % server.port
+    assert server.url == server.host + '/'
+    server.ip = '127.0.0.1'
+    assert server.host == 'http://127.0.0.1:%i' % server.port
+    assert server.url == server.host + '/'
 
 
 def test_proxy(db):


### PR DESCRIPTION
turn '' into 'localhost', so that it is a valid URL for connection

moves the same change from `wait_up` up one level to Server.host

closes #164