### PR TITLE
don't depend on ipython[notebook] in requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
     - npm install -g less bower jupyter/configurable-http-proxy
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install  -f travis-wheels/wheelhouse -r dev-requirements.txt .
+    - pip install -f travis-wheels/wheelhouse -r dev-requirements.txt .
+    - pip install -f travis-wheels/wheelhouse ipython[notebook]
 script:
     - py.test jupyterhub

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipython[notebook]>=3
+ipython>=3
 tornado>=4
 jinja2
 simplepam


### PR DESCRIPTION
it's not always required that the notebook server run in the same env (docker), and non-setuptools installs of ipython (conda) prevent extras from being defined.