### PR TITLE
use scoped session

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -21,6 +21,7 @@ if sys.version_info[:2] < (3,3):
 from jinja2 import Environment, FileSystemLoader
 
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import scoped_session
 
 import tornado.httpserver
 import tornado.options
@@ -538,7 +539,7 @@ class JupyterHub(Application):
                 echo=self.debug_db,
                 **self.db_kwargs
             )
-            self.db = self.session_factory()
+            self.db = scoped_session(self.session_factory)()
         except OperationalError as e:
             self.log.error("Failed to connect to db: %s", self.db_url)
             self.log.debug("Database error was:", exc_info=True)

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -22,7 +22,7 @@ def db():
     """Get a db session"""
     global _db
     if _db is None:
-        _db = orm.new_session_factory('sqlite:///:memory:')()
+        _db = orm.new_session_factory('sqlite:///:memory:', echo=True)()
         user = orm.User(
             name=getuser(),
             server=orm.Server(),


### PR DESCRIPTION
makes sessions use threadlocal storage

doesn't actually matter for real usage, where only one thread is active, but may help in multi-threaded tests