### PR TITLE
DEV: Make the timeout used by wait_for_http_server configurable.

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -367,12 +367,17 @@ class User(Base):
         self.last_activity = datetime.utcnow()
         db.commit()
         try:
-            yield self.server.wait_up(http=True)
+            yield self.server.wait_up(http=True, timeout=spawner.http_timeout)
         except Exception as e:
             if isinstance(e, TimeoutError):
-                self.log.warn("{user}'s server never showed up at {url}, giving up".format(
-                    user=self.name, url=self.server.url,
-                ))
+                self.log.warn(
+                    "{user}'s server never showed up at {url} "
+                    "after {http_timeout} seconds. Giving up".format(
+                        user=self.name,
+                        url=self.server.url,
+                        http_timeout=spawner.http_timeout,
+                    )
+                )
             else:
                 self.log.error("Unhandled error waiting for {user}'s server to show up at {url}: {error}".format(
                     user=self.name, url=self.server.url, error=e,

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -52,7 +52,17 @@ class Spawner(LoggingConfigurable):
         start should return when the server process is started and its location is known.
         """
     )
-    
+
+    http_timeout = Integer(
+        10, config=True,
+        help="""Timeout (in seconds) before giving up on a spawned HTTP server
+
+        Once a server has successfully been spawned, this is the amount of time
+        we wait before assuming that the server is unable to accept
+        connections.
+        """
+    )
+
     poll_interval = Integer(30, config=True,
         help="""Interval (in seconds) on which to poll the spawner."""
     )


### PR DESCRIPTION
On slow or heavily-populated hardware it can take more than 10 seconds for HTTP servers to come up after successful spawn.  This makes the timeout used in wait_for_http_server configurable.