### PR TITLE
don't pretend `npm install -g` works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - 3.3
 before_install:
     - npm install
-    - npm install -g
+    - npm install -g configurable-http-proxy
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
     - pip install -f travis-wheels/wheelhouse -r dev-requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 
 # install js dependencies
 RUN npm install
-RUN npm install -g
+RUN npm install -g configurable-http-proxy
 
 RUN mkdir -p /srv/
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ which is required for npm to work on Debian/Ubuntu at this point)
 
 Then install javascript dependencies:
 
-    sudo npm install -g
+    sudo npm install -g configurable-http-proxy
 
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   "type": "git",
   "url": "https://github.com/jupyter/jupyterhub.git"
  },
- "dependencies": {
-  "configurable-http-proxy": "*"
- },
  "devDependencies": {
   "bower": "*",
   "less": "~2",


### PR DESCRIPTION
install configurable-http-proxy explicitly

because dependencies aren't installed anywhere on PATH

closes #172