### PR TITLE
better error messages for spawn failure

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -22,6 +22,13 @@ from ..utils import url_path_join
 # pattern for the authentication token header
 auth_header_pat = re.compile(r'^token\s+([^\s]+)$')
 
+# mapping of reason: reason_message
+reasons = {
+    'timeout': "Failed to reach your server."
+        "  Please try again later."
+        "  Contact admin if the issue persists.",
+    'error': "Failed to start your server.  Please contact admin.",
+}
 
 class BaseHandler(RequestHandler):
     """Base Handler class with access to common methods and properties."""
@@ -310,7 +317,7 @@ class BaseHandler(RequestHandler):
             # construct the custom reason, if defined
             reason = getattr(exception, 'reason', '')
             if reason:
-                status_message = reason
+                message = reasons.get(reason, reason)
 
         # build template namespace
         ns = dict(

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -348,10 +348,12 @@ class User(Base):
                 self.log.warn("{user}'s server failed to start in {s} seconds, giving up".format(
                     user=self.name, s=spawner.start_timeout,
                 ))
+                e.reason = 'timeout'
             else:
                 self.log.error("Unhandled error starting {user}'s server: {error}".format(
                     user=self.name, error=e,
                 ))
+                e.reason = 'error'
             try:
                 yield self.stop()
             except Exception:
@@ -378,7 +380,9 @@ class User(Base):
                         http_timeout=spawner.http_timeout,
                     )
                 )
+                e.reason = 'timeout'
             else:
+                e.reason = 'error'
                 self.log.error("Unhandled error waiting for {user}'s server to show up at {url}: {error}".format(
                     user=self.name, url=self.server.url, error=e,
                 ))

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -54,7 +54,7 @@ class Spawner(LoggingConfigurable):
     )
 
     http_timeout = Integer(
-        10, config=True,
+        30, config=True,
         help="""Timeout (in seconds) before giving up on a spawned HTTP server
 
         Once a server has successfully been spawned, this is the amount of time

--- a/share/jupyter/hub/static/less/error.less
+++ b/share/jupyter/hub/static/less/error.less
@@ -10,17 +10,12 @@ div.ajax-error {
 }
 
 div.error > h1 {
-    font-size: 500%;
-    line-height: normal;
+  font-size: 300%;
+  line-height: normal;
 }
 
 div.error > p {
-    font-size: 200%;
-    line-height: normal;
+  font-size: 200%;
+  line-height: normal;
 }
 
-div.traceback-wrapper {
-    text-align: left;
-    max-width: 800px;
-    margin: auto;
-}

--- a/share/jupyter/hub/templates/error.html
+++ b/share/jupyter/hub/templates/error.html
@@ -6,17 +6,18 @@
 {% block main %}
 
 <div class="error">
-    {% block h1_error %}
-    <h1>{{status_code}} : {{status_message}}</h1>
-    {% endblock h1_error %}
-    {% block error_detail %}
-    {% if message %}
-    <p>The error was:</p>
-    <div class="traceback-wrapper">
-    <pre class="traceback">{{message}}</pre>
-    </div>
-    {% endif %}
-    {% endblock %}
+  {% block h1_error %}
+  <h1>
+    {{status_code}} : {{status_message}}
+  </h1>
+  {% endblock h1_error %}
+  {% block error_detail %}
+  {% if message %}
+  <p>
+    {{message}}
+  </p>
+  {% endif %}
+  {% endblock error_detail %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Server started, but never became accessible:

> Failed to reach your server.
> Please try again later.
> Contact admin if the issue persists.

Server failed to start (errors in Spawner):

> Failed to start your server.
> Please contact admin.

Bump default http timeout to 30 seconds. 10 can be too brief, even on moderately slow laptops.

closes #187