### PR TITLE
url logging

### DIFF
--- a/jupyterhub/apihandlers/proxy.py
+++ b/jupyterhub/apihandlers/proxy.py
@@ -58,7 +58,7 @@ class ProxyAPIHandler(APIHandler):
         if 'auth_token' in model:
             self.proxy.auth_token = model['auth_token']
         self.db.commit()
-        self.log.info("Updated proxy at %s", server.url)
+        self.log.info("Updated proxy at %s", server.bind_url)
         yield self.proxy.check_routes()
         
 

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -75,18 +75,33 @@ class Server(Base):
     
     @property
     def host(self):
+        ip = self.ip
+        if ip in {'', '0.0.0.0'}:
+            # when listening on all interfaces, connect to localhost
+            ip = 'localhost'
         return "{proto}://{ip}:{port}".format(
             proto=self.proto,
-            ip=self.ip or 'localhost',
+            ip=ip,
             port=self.port,
         )
-    
+
     @property
     def url(self):
         return "{host}{uri}".format(
             host=self.host,
             uri=self.base_url,
         )
+    
+    @property
+    def bind_url(self):
+        """representation of URL used for binding
+        
+        Never used in APIs, only logging,
+        since it can be non-connectable value, such as '', meaning all interfaces.
+        """
+        if self.ip in {'', '0.0.0.0'}:
+            return self.url.replace('localhost', self.ip or '*', 1)
+        return self.url
     
     @gen.coroutine
     def wait_up(self, timeout=10, http=False):

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -21,6 +21,7 @@ def test_server(db):
     assert isinstance(server.cookie_name, str)
     assert server.host == 'http://localhost:%i' % server.port
     assert server.url == server.host + '/'
+    assert server.bind_url == 'http://*:%i/' % server.port
     server.ip = '127.0.0.1'
     assert server.host == 'http://127.0.0.1:%i' % server.port
     assert server.url == server.host + '/'


### PR DESCRIPTION
log the actual bind url (Server.bind_url), rather than the connect url (Server.url), which converts all-interfaces IPs to 'localhost'

add a log statement when binding Hub, to indicate the URL that failed to bind