### PR TITLE
DEV: Allow setting a whitelist_group on LocalAuthenticator.

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -115,12 +115,15 @@ class LocalAuthenticator(Authenticator):
     def check_group_whitelist(self, username):
         if not self.group_whitelist:
             return False
-        try:
-            group = getgrnam(self.group_whitelist)
-        except KeyError:
-            self.log.error('No such group: [%s]' % self.group_whitelist)
-            return False
-        return username in group.gr_mem
+        for group in self.group_whitelist:
+            try:
+                group = getgrnam(self.group_whitelist)
+            except KeyError:
+                self.log.error('No such group: [%s]' % self.group_whitelist)
+                continue
+            if username in group.gr_mem:
+                return True
+        return False
 
     @gen.coroutine
     def add_user(self, user):


### PR DESCRIPTION
Any user in the group is considered in the whitelist.

One issue that arises as a result of this PR is that it seems reasonable to have an empty whitelist of users if you're specifying a whitelist group, but that's currently not possible because the hub requires you to have an admin user and places them into the whitelist.