### PR TITLE
spawner.py update for default shell

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -81,7 +81,6 @@ class Spawner(LoggingConfigurable):
         'VIRTUAL_ENV',
         'LANG',
         'LC_ALL',
-        'SHELL'
     ], config=True,
         help="Whitelist of environment variables for the subprocess to inherit"
     )
@@ -331,6 +330,7 @@ class LocalProcessSpawner(Spawner):
     def user_env(self, env):
         env['USER'] = self.user.name
         env['HOME'] = pwd.getpwnam(self.user.name).pw_dir
+        env['SHELL'] = pwd.getpwnam(self.user.name).pw_shell
         return env
     
     def _env_default(self):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -81,6 +81,7 @@ class Spawner(LoggingConfigurable):
         'VIRTUAL_ENV',
         'LANG',
         'LC_ALL',
+        'SHELL'
     ], config=True,
         help="Whitelist of environment variables for the subprocess to inherit"
     )


### PR DESCRIPTION
Update spawner.py to do a better job keeping the shell variable intact for terminals launched from within the notebook.

Exporting the SHELL environment variable when launching jupyterhub should now use that shell for terminado terminals.  I set this in my /etc/init.d/jupyter script.  This should fix issue #133 