### PR TITLE
use `cookie_name/cookie_value` URL for cookie checking API

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -11,7 +11,6 @@ from ..utils import token_authenticated
 from .base import APIHandler
 
 
-
 class TokenAPIHandler(APIHandler):
     @token_authenticated
     def get(self, token):
@@ -22,10 +21,15 @@ class TokenAPIHandler(APIHandler):
             'user' : orm_token.user.name,
         }))
 
+
 class CookieAPIHandler(APIHandler):
     @token_authenticated
-    def get(self, cookie_name):
-        cookie_value = self.request.body
+    def get(self, cookie_name, cookie_value=None):
+        if cookie_value is None:
+            self.log.warn("Cookie values in request body is deprecated, use `/cookie_name/cookie_value`")
+            cookie_value = self.request.body
+        else:
+            cookie_value = cookie_value.encode('utf8')
         user = self._user_for_cookie(cookie_name, cookie_value)
         if user is None:
             raise web.HTTPError(404)
@@ -33,7 +37,8 @@ class CookieAPIHandler(APIHandler):
             'user' : user.name,
         }))
 
+
 default_handlers = [
-    (r"/api/authorizations/cookie/([^/]+)", CookieAPIHandler),
+    (r"/api/authorizations/cookie/([^/]+)(?:/([^/]+))?", CookieAPIHandler),
     (r"/api/authorizations/token/([^/]+)", TokenAPIHandler),
 ]

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -48,10 +48,9 @@ class JupyterHubLoginHandler(LoginHandler):
         hub_api_url = self.settings['hub_api_url']
         hub_api_key = self.settings['hub_api_key']
         r = requests.get(url_path_join(
-            hub_api_url, "authorizations/cookie", cookie_name,
+            hub_api_url, "authorizations/cookie", cookie_name, encrypted_cookie,
         ),
             headers = {'Authorization' : 'token %s' % hub_api_key},
-            data=encrypted_cookie,
         )
         if r.status_code == 404:
             data = None

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
+from urllib.parse import quote
 
 import requests
 
@@ -48,7 +49,7 @@ class JupyterHubLoginHandler(LoginHandler):
         hub_api_url = self.settings['hub_api_url']
         hub_api_key = self.settings['hub_api_key']
         r = requests.get(url_path_join(
-            hub_api_url, "authorizations/cookie", cookie_name, encrypted_cookie,
+            hub_api_url, "authorizations/cookie", cookie_name, quote(encrypted_cookie, safe=''),
         ),
             headers = {'Authorization' : 'token %s' % hub_api_key},
         )


### PR DESCRIPTION
instead of putting the value in the request body, which is verboten for GET requests


/cc @jdfreder