### PR TITLE
reply with full user model in auth handlers

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -17,9 +17,7 @@ class TokenAPIHandler(APIHandler):
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
             raise web.HTTPError(404)
-        self.write(json.dumps({
-            'user' : orm_token.user.name,
-        }))
+        self.write(json.dumps(self.user_model(orm_token.user)))
 
 
 class CookieAPIHandler(APIHandler):
@@ -33,9 +31,7 @@ class CookieAPIHandler(APIHandler):
         user = self._user_for_cookie(cookie_name, cookie_value)
         if user is None:
             raise web.HTTPError(404)
-        self.write(json.dumps({
-            'user' : user.name,
-        }))
+        self.write(json.dumps(self.user_model(user)))
 
 
 default_handlers = [

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -47,3 +47,33 @@ class APIHandler(BaseHandler):
             'status': status_code,
             'message': message or status_message,
         }))
+
+    def user_model(self, user):
+        model = {
+            'name': user.name,
+            'admin': user.admin,
+            'server': user.server.base_url if user.running else None,
+            'pending': None,
+            'last_activity': user.last_activity.isoformat(),
+        }
+        if user.spawn_pending:
+            model['pending'] = 'spawn'
+        elif user.stop_pending:
+            model['pending'] = 'stop'
+        return model
+    
+    _model_types = {
+        'name': str,
+        'admin': bool,
+    }
+    
+    def _check_user_model(self, model):
+        if not isinstance(model, dict):
+            raise web.HTTPError(400, "Invalid JSON data: %r" % model)
+        if not set(model).issubset(set(self._model_types)):
+            raise web.HTTPError(400, "Invalid JSON keys: %r" % model)
+        for key, value in model.items():
+            if not isinstance(value, self._model_types[key]):
+                raise web.HTTPError(400, "user.%s must be %s, not: %r" % (
+                    key, self._model_types[key], type(value)
+                ))

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -81,7 +81,7 @@ def test_auth_api(app):
     r = api_request(app, 'authorizations/token', api_token)
     assert r.status_code == 200
     reply = r.json()
-    assert reply['user'] == user.name
+    assert reply['name'] == user.name
     
     # check fail
     r = api_request(app, 'authorizations/token', api_token,


### PR DESCRIPTION
Mainly this adds the `admin` key,
but I don't see a reason to respond with different subsets of the user model in different circumstances.

based on #207