### PR TITLE
switched app and singleuser to run under python3 by default

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """The multi-user notebook application"""
 
 # Copyright (c) Jupyter Development Team.

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Extend regular notebook server to be aware of multiuser things."""
 
 # Copyright (c) Jupyter Development Team.


### PR DESCRIPTION
Allows singleuser.py to be run as a command-line script with python3 automatically. This fixes https://github.com/jupyter/dockerspawner/issues/29.