### PR TITLE
base64 encode username in cookie_name to accommodate special chars in em...

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -4,7 +4,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import re
-import base64
 from datetime import datetime, timedelta
 from http.client import responses
 
@@ -142,10 +141,7 @@ class BaseHandler(RequestHandler):
         """Get ORM User for username"""
         user = self.find_user(username)
         if user is None:
-            user = orm.User(
-                name=username, 
-                b64_name=base64.b64encode(bytes(username, "utf8")).decode("utf8").strip("=")
-            )
+            user = orm.User(name=username)
             self.db.add(user)
             self.db.commit()
         return user
@@ -400,7 +396,6 @@ class UserSpawnHandler(BaseHandler):
             self.set_login_cookie(current_user)
             without_prefix = self.request.path[len(self.hub.server.base_url):]
             target = url_path_join(self.base_url, without_prefix)
-            self.log.warn(target)
             self.redirect(target)
         else:
             # not logged in to the right user,

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -7,8 +7,6 @@ from datetime import datetime, timedelta
 import errno
 import json
 import socket
-import base64
-import urllib.parse
 
 from tornado import gen
 from tornado.log import app_log

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import errno
 import json
 import socket
+import base64
 
 from tornado import gen
 from tornado.log import app_log
@@ -333,8 +334,10 @@ class User(Base):
         db = inspect(self).session
         if hub is None:
             hub = db.query(Hub).first()
+
+        cookiesafe_username = base64.b64encode(bytes(self.name, "utf8")).decode("utf8").strip("=")
         self.server = Server(
-            cookie_name='%s-%s' % (hub.server.cookie_name, self.name),
+            cookie_name='%s-%s' % (hub.server.cookie_name, cookiesafe_username),
             base_url=url_path_join(base_url, 'user', self.name),
         )
         db.add(self.server)


### PR DESCRIPTION
Fixes https://github.com/jupyter/jupyterhub/issues/218. 

Could *potentially* cause upgrade problems if existing usernames collide with base-64 representations of new usernames. E.g., if a user named "c2FtcGxldXNlcg" already exists in the database with cookie name "jupyter-hub-token-c2FtcGxldXNlcg", and a new user named "sampleuser" comes along, (base-64 encoded as "c2FtcGxldXNlcg"), the cookie names would collide. Maybe we should add a prefix (e.g., "jupyter-hub-token-b64-"), but there's no way to ensure that it won't collide with existing usernames in some case.