### PR TITLE
Get url_path_join from jupyter_notebook

### DIFF
--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -14,7 +14,10 @@ from tornado import web, gen, ioloop
 from tornado.httpclient import AsyncHTTPClient, HTTPError
 from tornado.log import app_log
 
-from IPython.html.utils import url_path_join
+try:
+    from jupyter_notebook.utils import url_path_join
+except:
+    from IPython.html.utils import url_path_join
 
 
 def random_port():


### PR DESCRIPTION
Since the commit https://github.com/ipython/ipython/commit/e65db1aa9317b21d8c9e8a51ff04f24cda96e843 url_path_join must be retrieved from jupyter_notebook (right?)