### PR TITLE
quote usernames in URLs, cookies

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+from urllib.parse import quote
 
 from tornado import web
 from .. import orm
@@ -25,6 +26,7 @@ class TokenAPIHandler(APIHandler):
 class CookieAPIHandler(APIHandler):
     @token_authenticated
     def get(self, cookie_name, cookie_value=None):
+        cookie_name = quote(cookie_name, safe='')
         if cookie_value is None:
             self.log.warn("Cookie values in request body is deprecated, use `/cookie_name/cookie_value`")
             cookie_value = self.request.body

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import errno
 import json
 import socket
+from urllib.parse import quote
 
 from tornado import gen
 from tornado.log import app_log
@@ -145,7 +146,7 @@ class Proxy(Base):
             )
         else:
             return "<%s [unconfigured]>" % self.__class__.__name__
-
+    
     def api_request(self, path, method='GET', body=None, client=None):
         """Make an authenticated API request of the proxy"""
         client = client or AsyncHTTPClient()
@@ -300,6 +301,11 @@ class User(Base):
             )
     
     @property
+    def escaped_name(self):
+        """My name, escaped for use in URLs, cookies, etc."""
+        return quote(self.name, safe='@')
+    
+    @property
     def running(self):
         """property for whether a user has a running server"""
         if self.spawner is None:
@@ -333,9 +339,10 @@ class User(Base):
         db = inspect(self).session
         if hub is None:
             hub = db.query(Hub).first()
+        
         self.server = Server(
-            cookie_name='%s-%s' % (hub.server.cookie_name, self.name),
-            base_url=url_path_join(base_url, 'user', self.name),
+            cookie_name='%s-%s' % (hub.server.cookie_name, quote(self.name, safe='')),
+            base_url=url_path_join(base_url, 'user', self.escaped_name),
         )
         db.add(self.server)
         db.commit()


### PR DESCRIPTION
- allow @ to be left unescaped in URLs
- quote everything in cookie names

requires configurable-http-proxy >= 0.3 to work properly (released today)

closes #218 