### PR TITLE
create multiple users in admin panel

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -30,13 +30,19 @@ class UserListAPIHandler(APIHandler):
         admin = data.get('admin', False)
         self._check_user_model(data)
         
+        to_create = []
         for name in usernames:
             user = self.find_user(name)
             if user is not None:
-                raise web.HTTPError(400, "User %s already exists" % name)
+                self.log.warn("User %s already exists" % name)
+            else:
+                to_create.append(name)
+        
+        if not to_create:
+            raise web.HTTPError(400, "All %i users already exist" % len(usernames))
         
         created = []
-        for name in usernames:
+        for name in to_create:
             user = self.user_from_username(name)
             if admin:
                 user.admin = True

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -27,8 +27,10 @@ class UserListAPIHandler(APIHandler):
             raise web.HTTPError(400, "Must specify at least one user to create")
         
         usernames = data.pop('usernames')
-        admin = data.get('admin', False)
         self._check_user_model(data)
+        # admin is set for all users
+        # to create admin and non-admin users requires at least two API requests
+        admin = data.get('admin', False)
         
         to_create = []
         for name in usernames:

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -23,11 +23,11 @@ class UserListAPIHandler(APIHandler):
     @gen.coroutine
     def post(self):
         data = self.get_json_body()
-        print(data)
         if not data or not isinstance(data, dict) or not data.get('usernames'):
             raise web.HTTPError(400, "Must specify at least one user to create")
         
         usernames = data.pop('usernames')
+        admin = data.get('admin', False)
         self._check_user_model(data)
         
         for name in usernames:
@@ -38,11 +38,9 @@ class UserListAPIHandler(APIHandler):
         created = []
         for name in usernames:
             user = self.user_from_username(name)
-            if data:
-                self._check_user_model(data)
-                if 'admin' in data:
-                    user.admin = data['admin']
-                    self.db.commit()
+            if admin:
+                user.admin = True
+                self.db.commit()
             try:
                 yield gen.maybe_future(self.authenticator.add_user(user))
             except Exception:

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -177,6 +177,17 @@ def test_add_multi_user(app):
         data=json.dumps({'usernames': names}),
     )
     assert r.status_code == 400
+    
+    names = ['a', 'b', 'ab']
+    
+    # try to create the same users again
+    r = api_request(app, 'users', method='post',
+        data=json.dumps({'usernames': names}),
+    )
+    assert r.status_code == 201
+    reply = r.json()
+    r_names = [ user['name'] for user in reply ]
+    assert r_names == ['ab']
 
 
 def test_add_multi_user_admin(app):

--- a/share/jupyter/hub/static/js/admin.js
+++ b/share/jupyter/hub/static/js/admin.js
@@ -42,7 +42,7 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
     $("th").map(function (i, th) {
         th = $(th);
         var col = th.data('sort');
-        if (!col || col.length == 0) {
+        if (!col || col.length === 0) {
             return;
         }
         var order = th.find('i').hasClass('fa-sort-desc') ? 'asc':'desc';
@@ -50,7 +50,7 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
             function () {
                 resort(col, order);
             }
-        )
+        );
     });
     
     $(".time-col").map(function (i, el) {
@@ -161,9 +161,17 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
 
     $("#add-user-dialog").find(".save-button").click(function () {
         var dialog = $("#add-user-dialog");
-        var username = dialog.find(".username-input").val();
+        var lines = dialog.find(".username-input").val().split('\n');
         var admin = dialog.find(".admin-checkbox").prop("checked");
-        api.add_user(username, {admin: admin}, {
+        var usernames = [];
+        lines.map(function (line) {
+            var username = line.trim();
+            if (username.length) {
+                usernames.push(username);
+            }
+        });
+        
+        api.add_users(usernames, {admin: admin}, {
             success: function () {
                 window.location.reload();
             }

--- a/share/jupyter/hub/static/js/jhapi.js
+++ b/share/jupyter/hub/static/js/jhapi.js
@@ -72,18 +72,16 @@ define(['jquery', 'utils'], function ($, utils) {
         );
     };
     
-    JHAPI.prototype.add_user = function (user, userinfo, options) {
+    JHAPI.prototype.add_users = function (usernames, userinfo, options) {
         options = options || {};
+        var data = update(userinfo, {usernames: usernames});
         options = update(options, {
             type: 'POST',
             dataType: null,
-            data: JSON.stringify(userinfo)
+            data: JSON.stringify(data)
         });
         
-        this.api_request(
-            utils.url_path_join('users', user),
-            options
-        );
+        this.api_request('users', options);
     };
     
     JHAPI.prototype.edit_user = function (user, userinfo, options) {

--- a/share/jupyter/hub/templates/admin.html
+++ b/share/jupyter/hub/templates/admin.html
@@ -86,10 +86,17 @@
   </div>
 {% endcall %}
 
-{% macro user_modal(name) %}
+{% macro user_modal(name, multi=False) %}
 {% call modal(name, btn_class='btn-primary save-button') %}
 <div class="form-group">
-  <input type="text" class="form-control username-input" placeholder="username">
+  <{%- if multi -%}
+    textarea
+    {%- else -%}
+    input type="text"
+    {%- endif %}
+    class="form-control username-input"
+    placeholder="{%- if multi -%} usernames separated by lines{%- else -%} username {%-endif-%}">
+  {%- if multi -%}</textarea>{%- endif -%}
 </div>
 <div class="checkbox">
   <label>
@@ -101,7 +108,7 @@
 
 {{ user_modal('Edit User') }}
 
-{{ user_modal('Add User') }}
+{{ user_modal('Add User', multi=True) }}
 
 {% endblock %}
 


### PR DESCRIPTION
usernames separated by lines

adds POST /users endpoint for multi-user creation with a single request, so we don't need to make N API requests.

closes #225 