### PR TITLE
Include query arguments in GET requests to the notebook server (once it spawns)

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -390,7 +390,7 @@ class PrefixRedirectHandler(BaseHandler):
     Redirects /foo to /prefix/foo, etc.
     """
     def get(self):
-        path = self.request.path[len(self.base_url):]
+        path = self.request.uri[len(self.base_url):]
         self.redirect(url_path_join(
             self.hub.server.base_url, path,
         ), permanent=False)
@@ -420,7 +420,7 @@ class UserSpawnHandler(BaseHandler):
                 yield self.spawn_single_user(current_user)
             # set login cookie anew
             self.set_login_cookie(current_user)
-            without_prefix = self.request.path[len(self.hub.server.base_url):]
+            without_prefix = self.request.uri[len(self.hub.server.base_url):]
             target = url_path_join(self.base_url, without_prefix)
             self.redirect(target)
         else:
@@ -429,7 +429,7 @@ class UserSpawnHandler(BaseHandler):
             self.clear_login_cookie()
             self.redirect(url_concat(
                 self.settings['login_url'],
-                {'next': self.request.path,
+                {'next': self.request.uri,
             }))
 
 default_handlers = [


### PR DESCRIPTION
The problem: When a GET request includes query arguments, and also triggers a notebook server spawn, the query arguments don't get passed through to the notebook server once it's spawned.

Using self.request.uri instead of self.request.path in a few places fixes this problem.