### PR TITLE
For a standard installation, 'pip install' has to be run with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ As usual start with cloning the code:
 Then you can install the Python package by doing:
 
     pip install -r requirements.txt
-    pip install .
+    sudo pip install .
 
 If you plan to run notebook servers locally, you may also need to install the IPython notebook:
 
-    pip install "ipython[notebook]"
+    sudo pip install "ipython[notebook]"
 
 
 This will fetch client-side javascript dependencies and compile CSS,


### PR DESCRIPTION
I needed to do this to install jupyterhub on my machine; that was the correct thing to do, right?