### PR TITLE
don't try to get notebook aliases from NotebookApp

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -23,7 +23,7 @@ from IPython.utils.traitlets import (
     CUnicode,
 )
 
-from IPython.html.notebookapp import NotebookApp
+from IPython.html.notebookapp import NotebookApp, aliases as notebook_aliases
 from IPython.html.auth.login import LoginHandler
 from IPython.html.auth.logout import LogoutHandler
 
@@ -109,7 +109,7 @@ class JupyterHubLogoutHandler(LogoutHandler):
 
 
 # register new hub related command-line aliases
-aliases = NotebookApp.aliases.get_default_value()
+aliases = dict(notebook_aliases)
 aliases.update({
     'user' : 'SingleUserNotebookApp.user',
     'cookie-name': 'SingleUserNotebookApp.cookie_name',


### PR DESCRIPTION
Sentinel changes make it ~impossible to fetch values without instantiation,
which probably wasn't the best idea in the first place.