### PR TITLE
single-user should still be using IPython.utils.traitlets

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -17,7 +17,7 @@ from jinja2 import ChoiceLoader, FunctionLoader
 from tornado import ioloop
 from tornado.web import HTTPError
 
-from traitlets import (
+from IPython.utils.traitlets import (
     Integer,
     Unicode,
     CUnicode,

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -56,6 +56,30 @@ def test_spawner(db, io_loop):
     status = io_loop.run_sync(spawner.poll)
     assert status == 1
 
+def test_single_user_spawner(db, io_loop):
+    spawner = new_spawner(db, cmd=[sys.executable, '-m', 'jupyterhub.singleuser'])
+    io_loop.run_sync(spawner.start)
+    assert spawner.user.server.ip == 'localhost'
+    # wait for http server to come up,
+    # checking for early termination every 1s
+    def wait():
+        return spawner.user.server.wait_up(timeout=1, http=True)
+    for i in range(30):
+        status = io_loop.run_sync(spawner.poll)
+        assert status is None
+        try:
+            io_loop.run_sync(wait)
+        except TimeoutError:
+            continue
+        else:
+            break
+    io_loop.run_sync(wait)
+    status = io_loop.run_sync(spawner.poll)
+    assert status == None
+    io_loop.run_sync(spawner.stop)
+    status = io_loop.run_sync(spawner.poll)
+    assert status == 0
+
 
 def test_stop_spawner_sigint_fails(db, io_loop):
     spawner = new_spawner(db, cmd=[sys.executable, '-c', _uninterruptible])


### PR DESCRIPTION
We haven't moved to using notebook 4.0 in the single-user, yet.

closes #262