### PR TITLE
add supplemental groups to single-user servers

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -10,6 +10,7 @@ import pwd
 import re
 import signal
 import sys
+import grp
 from subprocess import Popen, check_output, PIPE, CalledProcessError
 from tempfile import TemporaryDirectory
 
@@ -282,6 +283,8 @@ def set_user_setuid(username):
         
         # set the user and group
         os.setgid(gid)
+        gids = [ g.gr_gid for g in grp.getgrall() if username in g.gr_mem ]
+        os.setgroups(gids)
         os.setuid(uid)
 
         # start in the user's home dir


### PR DESCRIPTION
Set the list of supplemental group ids for the user associated with the spawned notebook process. This allows users to access utilize their full complement of UNIX system groups. Currently the user is restricted to their default group - accessing a file owned by any other group does not work, even if a user is a member of that group. This patch fixes that.