### PR TITLE
Add some docs clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ You will need nodejs/npm, which you can get from your package manager:
 (The `nodejs-legacy` package installs the `node` executable,
 which is required for npm to work on Debian/Ubuntu at this point)
 
-Then install javascript dependencies:
+Then install javascript dependencies (note that the first `npm install` should *not* be run with sudo):
 
-    sudo npm install
+    npm install
     sudo npm install -g configurable-http-proxy
 
 ### Optional

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ which is required for npm to work on Debian/Ubuntu at this point)
 
 Then install javascript dependencies:
 
+    sudo npm install
     sudo npm install -g configurable-http-proxy
 
 ### Optional

--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ You will need nodejs/npm, which you can get from your package manager:
 (The `nodejs-legacy` package installs the `node` executable,
 which is required for npm to work on Debian/Ubuntu at this point)
 
-Then install javascript dependencies (note that the first `npm install` should *not* be run with sudo):
+Then install javascript dependencies:
 
-    npm install
     sudo npm install -g configurable-http-proxy
 
 ### Optional
@@ -58,6 +57,10 @@ Then you can install the Python package by doing:
 
     pip3 install -r requirements.txt
     pip3 install .
+    
+If the `pip3 install .` command fails and complains about `lessc` being unavailable, you may need to explicitly install some additional javascript dependencies:
+
+    npm install
 
 If you plan to run notebook servers locally, you may also need to install the IPython notebook:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,7 +130,7 @@ c.JupyterHub.proxy_api_ip = '10.0.1.4'
 c.JupyterHub.proxy_api_port = 5432
 ```
 
-The Hub service also listens only on localhost by default.
+The Hub service also listens only on localhost (port 8080) by default.
 The Hub needs needs to be accessible from both the proxy and all Spawners.
 When spawning local servers localhost is fine,
 but if *either* the Proxy or (more likely) the Spawners will be remote or isolated in containers,


### PR DESCRIPTION
1. If `lessc` isn't installed, it should be installed by running `npm install`. This is apparently done in the travis script and the dockerfile, but isn't actually in the installation docs (one thing I'm not sure on: should this be documented with `sudo`, or without `sudo`?)
2. I believe the hub service listens on port 8080 by default, but this isn't documented in the getting started doc.