### PR TITLE
ipython/ipython is deprecated.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # FROM jupyter/jupyterhub:latest
 #
 
-FROM ipython/ipython
+FROM jupyter/notebook
 
 MAINTAINER Jupyter Project <jupyter@googlegroups.com>
 


### PR DESCRIPTION
The correct one is now jupyter/notebook