### PR TITLE
Redirect unauthenticated root to login

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -25,15 +25,16 @@ class RootHandler(BaseHandler):
         if user:
             if user.running:
                 url = url_path_join(self.hub.server.base_url, user.server.base_url)
-                self.log.warn("User is running: %s", url)
+                self.log.debug("User is running: %s", url)
             else:
                 url = url_path_join(self.hub.server.base_url, 'home')
-                self.log.warn("User is not running: %s", url)
+                self.log.debug("User is not running: %s", url)
             self.redirect(url, permanent=False)
             return
-        # Redirect to the system login page
+        # Redirect to the authenticator login page instead of rendering the
+        # login html page
         url = self.authenticator.login_url(self.hub.server.base_url)
-        self.log.warn("No user logged in: %s", url)
+        self.log.debug("No user logged in: %s", url)
         self.redirect(url, permanent=False)
 
 class HomeHandler(BaseHandler):

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -24,16 +24,17 @@ class RootHandler(BaseHandler):
         user = self.get_current_user()
         if user:
             if user.running:
-                url = user.server.base_url
+                url = url_path_join(self.hub.server.base_url, user.server.base_url)
+                self.log.warn("User is running: %s", url)
             else:
                 url = url_path_join(self.hub.server.base_url, 'home')
+                self.log.warn("User is not running: %s", url)
             self.redirect(url, permanent=False)
             return
-        html = self.render_template('login.html',
-            login_url=self.settings['login_url'],
-            custom_html=self.authenticator.custom_html,
-        )
-        self.finish(html)
+        # Redirect to the system login page
+        url = self.authenticator.login_url(self.hub.server.base_url)
+        self.log.warn("No user logged in: %s", url)
+        self.redirect(url, permanent=False)
 
 class HomeHandler(BaseHandler):
     """Render the user's home page."""

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -18,7 +18,7 @@ def test_root_no_auth(app, io_loop):
     print(app.hub.server)
     r = requests.get(app.proxy.public_server.host)
     r.raise_for_status()
-    assert r.url == ujoin(app.proxy.public_server.host, app.hub.server.base_url)
+    assert r.url == ujoin(app.proxy.public_server.host, app.hub.server.base_url, 'login')
 
 def test_root_auth(app):
     cookies = app.login_user('river')


### PR DESCRIPTION
I was running into problems when trying to build an authenticator that didn't have a login page since he root handler rendered the login.html directly. This redirects to the authenticator's "login_url" instead.

This patch also makes the "url" for a running user a full path to fix a redirect loop I was having.