### PR TITLE
redirect unauthenticated root to *regular* login page

### DIFF
--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -28,6 +28,7 @@ class LoginHandler(BaseHandler):
                 username=username,
                 login_error=login_error,
                 custom_login_form=self.authenticator.custom_html,
+                login_url=self.settings['login_url'],
         )
     
     def get(self):
@@ -85,5 +86,6 @@ class LoginHandler(BaseHandler):
 
 # Only logout is a default handler.
 default_handlers = [
+    (r"/login", LoginHandler),
     (r"/logout", LogoutHandler),
 ]

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -8,6 +8,7 @@ from tornado import web
 from .. import orm
 from ..utils import admin_only, url_path_join
 from .base import BaseHandler
+from .login import LoginHandler
 
 
 class RootHandler(BaseHandler):
@@ -29,13 +30,11 @@ class RootHandler(BaseHandler):
             else:
                 url = url_path_join(self.hub.server.base_url, 'home')
                 self.log.debug("User is not running: %s", url)
-            self.redirect(url, permanent=False)
+            self.redirect(url)
             return
-        # Redirect to the authenticator login page instead of rendering the
-        # login html page
-        url = self.authenticator.login_url(self.hub.server.base_url)
-        self.log.debug("No user logged in: %s", url)
-        self.redirect(url, permanent=False)
+        url = url_path_join(self.hub.server.base_url, 'login')
+        self.redirect(url)
+
 
 class HomeHandler(BaseHandler):
     """Render the user's home page."""


### PR DESCRIPTION
instead of custom login_url, which may invisibly complete the login process with no action by the user.

partially reverts #276