### PR TITLE
Unset all login cookies

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -196,6 +196,7 @@ class UserAdminAccessAPIHandler(APIHandler):
         if not user.running:
             raise web.HTTPError(400, "%s's server is not running" % name)
         self.set_server_cookie(user)
+        current.other_user_cookies.add(name)
 
 
 default_handlers = [

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -179,8 +179,11 @@ class BaseHandler(RequestHandler):
             self.db.commit()
         return user
     
-    def clear_login_cookie(self):
-        user = self.get_current_user()
+    def clear_login_cookie(self, name=None):
+        if name is None:
+            user = self.get_current_user()
+        else:
+            user = self.find_user(name)
         if user and user.server:
             self.clear_cookie(user.server.cookie_name, path=user.server.base_url)
         self.clear_cookie(self.hub.server.cookie_name, path=self.hub.server.base_url)

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -18,6 +18,7 @@ class LogoutHandler(BaseHandler):
         self.clear_login_cookie()
         for name in user.other_user_cookies:
             self.clear_login_cookie(name)
+        user.other_user_cookies = set([])
         self.redirect(self.hub.server.base_url, permanent=False)
 
 

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -16,6 +16,8 @@ class LogoutHandler(BaseHandler):
         if user:
             self.log.info("User logged out: %s", user.name)
         self.clear_login_cookie()
+        for name in user.other_user_cookies:
+            self.clear_login_cookie(name)
         self.redirect(self.hub.server.base_url, permanent=False)
 
 

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -285,6 +285,8 @@ class User(Base):
     spawner = None
     spawn_pending = False
     stop_pending = False
+
+    other_user_cookies = set([])
     
     def __repr__(self):
         if self.server:


### PR DESCRIPTION
If jupyterhub is configured so that admin users can access other user's servers, then there is a bug where if the admin user requests access, then logs out, the cookie(s) for the other users are still set and so those servers can still be accessed. This PR fixes that by keeping a set of all users who the admin user has cookies for, and then unsetting those as well when they log out.