### PR TITLE
Load Authenticator handlers before default handlers

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -464,13 +464,12 @@ class JupyterHub(Application):
     
     def init_handlers(self):
         h = []
-        h.extend(handlers.default_handlers)
-        h.extend(apihandlers.default_handlers)
         # load handlers from the authenticator
         h.extend(self.authenticator.get_handlers(self))
-
+        # set default handlers
+        h.extend(handlers.default_handlers)
+        h.extend(apihandlers.default_handlers)
         self.handlers = self.add_url_prefix(self.hub_prefix, h)
-
         # some extra handlers, outside hub_prefix
         self.handlers.extend([
             (r"%s" % self.hub_prefix.rstrip('/'), web.RedirectHandler,


### PR DESCRIPTION
I changed the order for handlers so that the authenticator handler is added before the default handlers.  This would resolve issue #329.

This seems simple enough, but I am not an expert on the code base and am not sure if changing this order would have any unanticipated effects.

closes #329.