### PR TITLE
LDAP authenticator

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -53,7 +53,7 @@ from .utils import (
     ISO8601_ms, ISO8601_s,
 )
 # classes for config
-from .auth import Authenticator, PAMAuthenticator
+from .auth import Authenticator, PAMAuthenticator, LDAPAuthenticator
 from .spawner import Spawner, LocalProcessSpawner
 
 common_aliases = {
@@ -168,6 +168,7 @@ class JupyterHub(Application):
         LocalProcessSpawner,
         Authenticator,
         PAMAuthenticator,
+        LDAPAuthenticator
     ])
     
     config_file = Unicode('jupyterhub_config.py', config=True,


### PR DESCRIPTION
This is a followup on [1] where @minrk said:

> A custom LDAP Authenticator should be one of the simpler ones to write. Much simpler than GitHub 
> OAuth. You may want to grab a Python LDAP API, then you just need to relay the 
> username/password info you get from the authentication request to LDAP and return a username on successful auth.

I did just that. Revision would be much appreciated.

With auth out of the way, it hits another wall, AFAICS because a mapping from LDAP username to system username is missing. What would be a good way to handle this? Or is the proposal of Brendan Smithyman (see comment in [1]) a better way altogether?

```
[I 2015-11-17 13:59:04.466 JupyterHub app:1054] JupyterHub is now running at http://localhost:8000/
[I 2015-11-17 13:59:08.913 JupyterHub log:100] 302 GET / (@1.2.3.5) 6.21ms
[I 2015-11-17 13:59:08.919 JupyterHub log:100] 302 GET /hub (@1.2.3.5) 2.54ms
[I 2015-11-17 13:59:08.937 JupyterHub log:100] 302 GET /hub/ (@1.2.3.5) 3.05ms
[E 2015-11-17 13:59:17.858 JupyterHub orm:382] Unhandled error starting user@ldap.domain's server: 'getpwnam(): name not found: user@ldap.domain'
[E 2015-11-17 13:59:17.865 JupyterHub web:1524] Uncaught exception POST /hub/login?next= (1.2.3.5)
    HTTPServerRequest(protocol='http', host='1.2.3.4:8000', method='POST', uri='/hub/login?next=', version='HTTP/1.1', remote_ip='1.2.3.5', headers={'X-Forwarded-For': '1.2.3.5', 'Accept-Language': 'en-US,en;q=0.5', 'Accept-Encoding': 'gzip, deflate', 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'X-Forwarded-Proto': 'http', 'Cookie': '_ga=GA1.1.1310912651.1447149808; JSESSIONID.a128fb59=ba45lod72e771pmqfvqewmk4j; screenResolution=1080x1920', 'Content-Type': 'application/x-www-form-urlencoded', 'Host': '1.2.3.4:8000', 'X-Forwarded-Port': '8000', 'Referer': 'http://1.2.3.4:8000/hub/login', 'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:39.0) Gecko/20100101 Firefox/39.0', 'Connection': 'close', 'Content-Length': '60'})
    Traceback (most recent call last):
      File "/home/user/.virtualenvs/jupyterhub/lib/python3.4/site-packages/tornado/web.py", line 1445, in _execute
        result = yield result
      File "/home/user/jupyterhub/jupyterhub/handlers/login.py", line 72, in post
        yield self.spawn_single_user(user)
      File "/home/user/jupyterhub/jupyterhub/handlers/base.py", line 286, in spawn_single_user
        yield gen.with_timeout(timedelta(seconds=self.slow_spawn_timeout), f)
      File "/home/user/jupyterhub/jupyterhub/orm.py", line 392, in spawn
        raise e
      File "/home/user/jupyterhub/jupyterhub/orm.py", line 373, in spawn
        yield gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
      File "/home/user/jupyterhub/jupyterhub/spawner.py", line 358, in start
        env = self.env.copy()
      File "/home/user/.virtualenvs/jupyterhub/lib/python3.4/site-packages/traitlets/traitlets.py", line 439, in __get__
        value = self._validate(obj, dynamic_default())
      File "/home/user/jupyterhub/jupyterhub/spawner.py", line 349, in _env_default
        return self.user_env(env)
      File "/home/user/jupyterhub/jupyterhub/spawner.py", line 337, in user_env
        home = pwd.getpwnam(self.user.name).pw_dir
    KeyError: 'getpwnam(): name not found: user@ldap.domain'

[E 2015-11-17 13:59:17.898 JupyterHub log:99] {
      "X-Forwarded-For": "1.2.3.5",
      "Accept-Language": "en-US,en;q=0.5",
      "Accept-Encoding": "gzip, deflate",
      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
      "X-Forwarded-Proto": "http",
      "Cookie": "_ga=GA1.1.1310912651.1447149808; JSESSIONID.a128fb59=ba45lod72e771pmqfvqewmk4j; screenResolution=1080x1920",
      "Content-Type": "application/x-www-form-urlencoded",
      "Host": "1.2.3.4:8000",
      "X-Forwarded-Port": "8000",
      "Referer": "http://1.2.3.4:8000/hub/login",
      "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:39.0) Gecko/20100101 Firefox/39.0",
      "Connection": "close",
      "Content-Length": "60"
    }
[E 2015-11-17 13:59:17.900 JupyterHub log:100] 500 POST /hub/login?next= (@1.2.3.5) 112.66ms
```

[1] https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jupyter/lvCIb1nYNYk/4ed1cUSTeKkJ
