### PR TITLE
Log Remote IP Address for Failed Authentication Attempts

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -236,7 +236,10 @@ class PAMAuthenticator(LocalAuthenticator):
         try:
             pamela.authenticate(username, data['password'], service=self.service)
         except pamela.PAMError as e:
-            self.log.warn("PAM Authentication failed (@%s): %s", handler.request.remote_ip, e)
+            if handler is not None:
+                self.log.warn("PAM Authentication failed (@%s): %s", handler.request.remote_ip, e)
+            else:
+                self.log.warn("PAM Authentication failed: %s", e)
         else:
             return username
     

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -236,7 +236,7 @@ class PAMAuthenticator(LocalAuthenticator):
         try:
             pamela.authenticate(username, data['password'], service=self.service)
         except pamela.PAMError as e:
-            self.log.warn("PAM Authentication failed: %s", e)
+            self.log.warn("PAM Authentication failed (@%s): %s", handler.request.remote_ip, e)
         else:
             return username
     


### PR DESCRIPTION
Simple change to log the remote IP address for failed authentication attempts.

This is useful when combined with tools like [fail2ban](http://www.fail2ban.org/) that parse application logs for malicious behaviour.