### PR TITLE
require sqlalchemy 1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ traitlets>=4
 tornado>=4.1
 jinja2
 pamela
-sqlalchemy
+sqlalchemy>=1.0
 requests


### PR DESCRIPTION
we know 0.7.9 is too old. We might work on 0.8, but 1.0 is current.

closes #350