### PR TITLE
IPv6 ready /etc/hosts file without IPv6 enabled causing localhost issue

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -116,7 +116,17 @@ class Server(Base):
         try:
             socket.create_connection((self.ip or 'localhost', self.port))
         except socket.error as e:
-            if e.errno == errno.ECONNREFUSED:
+            if e.errno == errno.ENETUNREACH:
+                try:
+                    socket.create_connection((self.ip or '127.0.0.1', self.port))
+                except socket.error as e:
+                    if e.errno == errno.ECONNREFUSED:
+                        return False
+                    else:
+                       	raise
+                else:
+                    return True
+            elif e.errno == errno.ECONNREFUSED:
                 return False
             else:
                 raise


### PR DESCRIPTION
This is to resolve the 'Network is Unreachable' error experienced by a few when JupyterHUB is running on default localhost, see https://github.com/jupyter/jupyterhub/issues/271

On most recent linux OS versions like CentOS 6, 7, Red Hat 6, 7, Oracle Linux 6, 7, etc, the hosts file (/etc/hosts) usually has a line to make the server IPv6-ready:
    ::1 localhost
even if the given server actually has no IPv6 permissioned. In such case the Python socket library when connecting to 'localhost' will try to connect via the IPv6 protocol - which will fail with the 'Network is Unreachable' error.

To solve this we capture this error and try to reconnect on 127.0.0.1 instead of localhost, alias forcing the user of the IPv4 protocol.