### PR TITLE
delete users via UserDict API

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -53,8 +53,7 @@ class UserListAPIHandler(APIHandler):
                 yield gen.maybe_future(self.authenticator.add_user(user))
             except Exception:
                 self.log.error("Failed to create user: %s" % name, exc_info=True)
-                self.db.delete(user)
-                self.db.commit()
+                del self.users[user]
                 raise web.HTTPError(400, "Failed to create user: %s" % name)
             else:
                 created.append(user)
@@ -105,9 +104,7 @@ class UserAPIHandler(APIHandler):
         except Exception:
             self.log.error("Failed to create user: %s" % name, exc_info=True)
             # remove from registry
-            self.users.pop(user.id, None)
-            self.db.delete(user)
-            self.db.commit()
+            del self.users[user]
             raise web.HTTPError(400, "Failed to create user: %s" % name)
         
         self.write(json.dumps(self.user_model(user)))
@@ -130,10 +127,7 @@ class UserAPIHandler(APIHandler):
         
         yield gen.maybe_future(self.authenticator.delete_user(user))
         # remove from registry
-        self.users.pop(user.id, None)
-        # remove from the db
-        self.db.delete(user)
-        self.db.commit()
+        del self.users[user]
         
         self.set_status(204)
     

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -30,7 +30,14 @@ class UserDict(dict):
     def db(self):
         return self.db_factory()
     
+    def __contains__(self, key):
+        if isinstance(key, (User, orm.User)):
+            key = key.id
+        return dict.__contains__(self, key)
+    
     def __getitem__(self, key):
+        if isinstance(key, User):
+            key = key.id
         if isinstance(key, orm.User):
             # users[orm_user] returns User(orm_user)
             orm_user = key
@@ -50,6 +57,14 @@ class UserDict(dict):
             return dict.__getitem__(self, id)
         else:
             raise KeyError(repr(key))
+    
+    def __delitem__(self, key):
+        user = self[key]
+        user_id = user.id
+        db = self.db
+        db.delete(user.orm_user)
+        db.commit()
+        dict.__delitem__(self, user_id)
 
 
 class User(HasTraits):


### PR DESCRIPTION
avoids reusing user IDs when user creation fails

Fixes the most important part of #369