### PR TITLE
Username normalization and validation

### DIFF
--- a/docs/source/authenticators.md
+++ b/docs/source/authenticators.md
@@ -63,6 +63,36 @@ For local user authentication (e.g. PAM), this lets you limit which users
 can login.
 
 
+## Normalizing and validating usernames
+
+Since the Authenticator and Spawner both use the same username,
+sometimes you want to transform the name coming from the authentication service
+(e.g. turning email addresses into local system usernames) before adding them to the Hub service.
+Authenticators can define `normalize_username`, which takes a username.
+The default normalization is to cast names to lowercase
+
+For simple mappings, a configurable dict `Authenticator.username_map` is used to turn one name into another:
+
+```python
+c.Authenticator.username_map  = {
+  'service-name': 'localname'
+}
+
+### Validating usernames
+
+In most cases, there is a very limited set of acceptable usernames.
+Authenticators can define `validate_username(username)`,
+which should return True for a valid username and False for an invalid one.
+The primary effect this has is improving error messages during user creation.
+
+The default behavior is to use configurable `Authenticator.username_pattern`,
+which is a regular expression string for validation.
+
+To only allow usernames that start with 'w':
+
+    c.Authenticator.username_pattern = r'w.*'
+
+
 ## OAuth and other non-password logins
 
 Some login mechanisms, such as [OAuth][], don't map onto username+password.

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -63,10 +63,10 @@ class UserListAPIHandler(APIHandler):
                 self.db.commit()
             try:
                 yield gen.maybe_future(self.authenticator.add_user(user))
-            except Exception:
+            except Exception as e:
                 self.log.error("Failed to create user: %s" % name, exc_info=True)
                 del self.users[user]
-                raise web.HTTPError(400, "Failed to create user: %s" % name)
+                raise web.HTTPError(400, "Failed to create user %s: %s" % (name, str(e)))
             else:
                 created.append(user)
         

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -34,6 +34,7 @@ class UserListAPIHandler(APIHandler):
         
         to_create = []
         for name in usernames:
+            name = self.authenticator.normalize_username(name)
             user = self.find_user(name)
             if user is not None:
                 self.log.warn("User %s already exists" % name)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -634,6 +634,9 @@ class JupyterHub(Application):
             self.authenticator.normalize_username(name)
             for name in self.authenticator.admin_users
         ]
+        for username in admin_users:
+            if not self.authenticator.validate_username(username):
+                raise ValueError("username %r is not valid" % username)
         
         if not admin_users:
             self.log.warning("No admin users, admin interface will be unavailable.")
@@ -658,6 +661,9 @@ class JupyterHub(Application):
             self.authenticator.normalize_username(name)
             for name in self.authenticator.whitelist
         ]
+        for username in whitelist:
+            if not self.authenticator.validate_username(username):
+                raise ValueError("username %r is not valid" % username)
 
         if not whitelist:
             self.log.info("Not using whitelist. Any authenticated user will be allowed.")

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -630,7 +630,10 @@ class JupyterHub(Application):
                 "\nUse Authenticator.admin_users instead."
             )
             self.authenticator.admin_users = self.admin_users
-        admin_users = self.authenticator.admin_users
+        admin_users = [
+            self.authenticator.normalize_username(name)
+            for name in self.authenticator.admin_users
+        ]
         
         if not admin_users:
             self.log.warning("No admin users, admin interface will be unavailable.")
@@ -651,7 +654,10 @@ class JupyterHub(Application):
         # the admin_users config variable will never be used after this point.
         # only the database values will be referenced.
 
-        whitelist = self.authenticator.whitelist
+        whitelist = [
+            self.authenticator.normalize_username(name)
+            for name in self.authenticator.whitelist
+        ]
 
         if not whitelist:
             self.log.info("Not using whitelist. Any authenticated user will be allowed.")
@@ -671,7 +677,7 @@ class JupyterHub(Application):
             # but changes to the whitelist can occur in the database,
             # and persist across sessions.
             for user in db.query(orm.User):
-                whitelist.add(user.name)
+                self.authenticator.whitelist.add(user.name)
 
         # The whitelist set and the users in the db are now the same.
         # From this point on, any user changes should be done simultaneously

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -53,6 +53,15 @@ class Authenticator(LoggingConfigurable):
         """
     )
     
+    username_map = Dict(config=True,
+        help="""Dictionary mapping authenticator usernames to JupyterHub users.
+        
+        Can be used to map OAuth service names to local users, for instance.
+        
+        Used in normalize_username.
+        """
+    )
+    
     def normalize_username(self, username):
         """Normalize a username.
         
@@ -60,6 +69,7 @@ class Authenticator(LoggingConfigurable):
         Default: cast to lowercase, lookup in username_map.
         """
         username = username.lower()
+        username = self.username_map.get(username, username)
         return username
     
     def check_whitelist(self, username):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -247,7 +247,7 @@ class BaseHandler(RequestHandler):
     def authenticate(self, data):
         auth = self.authenticator
         if auth is not None:
-            result = yield auth.authenticate(self, data)
+            result = yield auth.get_authenticated_user(self, data)
             return result
         else:
             self.log.error("No authentication function, login is impossible!")

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -209,6 +209,17 @@ def test_add_multi_user_bad(app):
     r = api_request(app, 'users', method='post', data='[]')
     assert r.status_code == 400
 
+
+def test_add_multi_user_invalid(app):
+    app.authenticator.username_pattern = r'w.*'
+    r = api_request(app, 'users', method='post',
+        data=json.dumps({'usernames': ['Willow', 'Andrew', 'Tara']})
+    )
+    app.authenticator.username_pattern = ''
+    assert r.status_code == 400
+    assert r.json()['message'] == 'Invalid usernames: andrew, tara'
+
+
 def test_add_multi_user(app):
     db = app.db
     names = ['a', 'b']

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -169,3 +169,12 @@ def test_username_map(io_loop):
     assert authorized == 'inara'
 
 
+def test_validate_names(io_loop):
+    a = auth.PAMAuthenticator()
+    assert a.validate_username('willow')
+    assert a.validate_username('giles')
+    a = auth.PAMAuthenticator(username_pattern='w.*')
+    assert not a.validate_username('xander')
+    assert a.validate_username('willow')
+
+

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -153,3 +153,19 @@ def test_normalize_names(io_loop):
     assert authorized == 'zoe'
 
 
+def test_username_map(io_loop):
+    a = MockPAMAuthenticator(username_map={'wash': 'alpha'})
+    authorized = io_loop.run_sync(lambda : a.get_authenticated_user(None, {
+        'username': 'WASH',
+        'password': 'WASH',
+    }))
+
+    assert authorized == 'alpha'
+
+    authorized = io_loop.run_sync(lambda : a.get_authenticated_user(None, {
+        'username': 'Inara',
+        'password': 'Inara',
+    }))
+    assert authorized == 'inara'
+
+


### PR DESCRIPTION
General implementation:

Added top-level `get_authenticated_user`, which dispatches to authenticate, normalize, whitelist check, so that subclasses don't need to add these calls to their own authenticate methods.

Normalization:

- Add Authenticator.normalize_username
- Add Authenticator.username_map configurable dict for mapping names
- Default: lowercase, lookup in username_map

Validation:

- Add Authenticator.validate_username
- Default: look at `c.Authenticator.username_pattern` regex
- No validation is done by default


I also added the subprocess error output to the message in the Admin UI when creating a system user fails.

closes #369