### PR TITLE
Handle file upload in spawner form

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -87,6 +87,8 @@ class SpawnHandler(BaseHandler):
         form_options = {}
         for key, byte_list in self.request.body_arguments.items():
             form_options[key] = [ bs.decode('utf8') for bs in byte_list ]
+        for key, byte_list in self.request.files.items():
+            form_options["%s_file"%key] = byte_list
         options = user.spawner.options_from_form(form_options)
         yield self.spawn_single_user(user, options=options)
         self.set_login_cookie(user)

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -83,6 +83,8 @@ class FormSpawner(MockSpawner):
             options['bounds'] = [int(i) for i in form_data['bounds']]
         if 'energy' in form_data:
             options['energy'] = form_data['energy'][0]
+        if 'hello_file' in form_data:
+            options['hello'] = form_data['hello_file'][0]
         return options
 
 

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -119,3 +119,31 @@ def test_spawn_form(app, io_loop):
             'notspecified': 5,
         }
 
+def test_spawn_form_with_file(app, io_loop):
+    with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
+        base_url = ujoin(app.proxy.public_server.host, app.hub.server.base_url)
+        cookies = app.login_user('jones')
+        orm_u = orm.User.find(app.db, 'jones')
+        u = app.users[orm_u]
+        io_loop.run_sync(u.stop)
+
+        r = requests.post(ujoin(base_url, 'spawn'),
+                          cookies=cookies,
+                          data={
+                              'bounds': ['-1', '1'],
+                              'energy': '511keV',
+                          },
+                          files={'hello': ('hello.txt', b'hello world\n')}
+                      )
+        r.raise_for_status()
+        print(u.spawner)
+        print(u.spawner.user_options)
+        assert u.spawner.user_options == {
+            'energy': '511keV',
+            'bounds': [-1, 1],
+            'notspecified': 5,
+            'hello': {'filename': 'hello.txt',
+                      'body': b'hello world\n',
+                      'content_type': 'application/unknown'},
+        }
+

--- a/share/jupyter/hub/templates/spawn.html
+++ b/share/jupyter/hub/templates/spawn.html
@@ -7,7 +7,7 @@
     <h1>Spawner options</h1>
   </div>
   <div class="row col-sm-offset-2 col-sm-8">
-    <form id="spawn_form" action="{{base_url}}spawn" method="post" role="form">
+    <form enctype="multipart/form-data" id="spawn_form" action="{{base_url}}spawn" method="post" role="form">
       {{spawner_options_form}}
       <br>
       <input type="submit" value="Spawn" class="btn btn-jupyter">


### PR DESCRIPTION
Allow files to be uploaded in the spawner form. Files are added to `form_options` by adding `_file` to their key to allow separating them from other form items.

Unsure, but I don't think we need to do anything like `[ bs.decode('utf8') for bs in byte_list ]` for the files as they can contain all sorts of binary data.