### PR TITLE
Update project README to reflect docs on RTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Next, install JavaScript dependencies:
 
 ### (Optional) Installation Prerequisite (pip)
 
-Notes on `pip` command used in the below installation sections:
+Notes on the `pip` command used in the installation directions below:
 - `sudo` may be needed for `pip install`, depending on the user's filesystem permissions.
 - JupyterHub requires Python >= 3.3, so `pip3` may be required on some machines for package installation instead of `pip` (especially when both Python 2 and Python 3 are installed on a machine). If `pip3` is not found, install it using (on Linux Debian/Ubuntu):
 
-      sudo apt-get install python3-pip
+        sudo apt-get install python3-pip
 
 
 ## Installation
@@ -60,7 +60,7 @@ If the `pip3 install` command fails and complains about `lessc` being unavailabl
 If you plan to run notebook servers locally, you may also need to install the
 Jupyter ~~IPython~~ notebook:
 
-      pip3 install jupyter
+    pip3 install jupyter
 
 This will fetch client-side JavaScript dependencies and compile CSS,
 and install these files to `<sys.prefix>/share/jupyter`, as well as
@@ -97,7 +97,7 @@ configuration of the system.
 
 ## Getting started
 
-See the [getting started document](docs/source/getting-started.md) for some of the
+See the [getting started document](docs/source/getting-started.md) for the
 basics of configuring your JupyterHub deployment.
 
 ### Some examples

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 Questions, comments? Visit our Google Group:
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
+[![Build Status](https://travis-ci.org/jupyter/jupyterhub.svg?branch=master)](https://travis-ci.org/jupyter/jupyterhub)
+[![Documentation Status](https://readthedocs.org/projects/jupyterhub/badge/?version=latest)](http://jupyterhub.readthedocs.org/en/latest/?badge=latest)
 
-JupyterHub is a multi-user server that manages and proxies multiple instances of the single-user <del>IPython</del> Jupyter notebook server.
+JupyterHub, a multi-user server, manages and proxies multiple instances of the single-user <del>IPython</del> Jupyter notebook server.
 
 Three actors:
 
@@ -22,28 +24,27 @@ Basic principles:
 
 ## Dependencies
 
-JupyterHub requires IPython >= 3.0 (current master) and Python >= 3.3.
+JupyterHub requires [IPython](https://ipython.org/install.html) >= 3.0 (current master) and [Python](https://www.python.org/downloads/) >= 3.3.
 
-You will need nodejs/npm, which you can get from your package manager:
+Install [nodejs/npm](https://www.npmjs.com/), which is available from your
+package manager. For example, install on Linux (Debian/Ubuntu) using:
 
     sudo apt-get install npm nodejs-legacy
 
-(The `nodejs-legacy` package installs the `node` executable,
-which is required for npm to work on Debian/Ubuntu at this point)
+(The `nodejs-legacy` package installs the `node` executable and is currently
+required for npm to work on Debian/Ubuntu.)
 
-Then install javascript dependencies:
+Next, install JavaScript dependencies:
 
     sudo npm install -g configurable-http-proxy
 
-### Optional
+### Optional Installation Prerequisite (pip)
 
-- Notes on `pip` command used in the below installation sections:
-  - `sudo` may be needed for `pip install`, depending on filesystem permissions.
-  - JupyterHub requires Python >= 3.3, so it may be required on some machines to use `pip3` instead
-    of `pip` (especially when you have both Python 2 and Python 3 installed on your machine).
-    If `pip3` is not found on your machine, you can get it by doing:
+Notes on `pip` command used in the below installation sections:
+- `sudo` may be needed for `pip install`, depending on the user's filesystem permissions.
+- JupyterHub requires Python >= 3.3, so `pip3` may be required on some machines for package installation instead of `pip` (especially when both Python 2 and Python 3 are installed on a machine). If `pip3` is not found, install it using (on Linux Debian/Ubuntu):
 
-        sudo apt-get install python3-pip
+      sudo apt-get install python3-pip
 
 
 ## Installation
@@ -52,16 +53,17 @@ JupyterHub can be installed with pip:
 
     pip3 install jupyterhub
 
-If the `pip3 install .` command fails and complains about `lessc` being unavailable, you may need to explicitly install some additional javascript dependencies:
+If the `pip3 install` command fails and complains about `lessc` being unavailable, you may need to explicitly install some additional JavaScript dependencies:
 
     npm install
 
-If you plan to run notebook servers locally, you may also need to install the IPython notebook:
+If you plan to run notebook servers locally, you may also need to install the
+Jupyter ~~IPython~~ notebook:
 
-    pip3 install "ipython[notebook]"
+      pip3 install jupyter
 
-This will fetch client-side javascript dependencies and compile CSS,
-and install these files to `sys.prefix`/share/jupyter, as well as
+This will fetch client-side JavaScript dependencies and compile CSS,
+and install these files to `<sys.prefix>/share/jupyter`, as well as
 install any Python dependencies.
 
 
@@ -73,7 +75,7 @@ For a development install, clone the repository and then install from source:
     cd jupyterhub
     pip3 install -r dev-requirements.txt -e .
 
-In which case you may need to manually update javascript and css after some updates, with:
+You may also need to manually update JavaScript and CSS after some development updates, with:
 
     python3 setup.py js    # fetch updated client-side js (changes rarely)
     python3 setup.py css   # recompile CSS from LESS sources
@@ -87,22 +89,24 @@ To start the server, run the command:
 
 and then visit `http://localhost:8000`, and sign in with your unix credentials.
 
-If you want multiple users to be able to sign into the server, you will need to run the
-`jupyterhub` command as a privileged user, such as root.
-The [wiki](https://github.com/jupyter/jupyterhub/wiki/Using-sudo-to-run-JupyterHub-without-root-privileges) describes how to run the server
-as a less privileged user, which requires more configuration of the system.
+To allow multiple users to sign into the server, you will need to
+run the `jupyterhub` command as a *privileged user*, such as root.
+The [wiki](https://github.com/jupyter/jupyterhub/wiki/Using-sudo-to-run-JupyterHub-without-root-privileges)
+describes how to run the server as a *less privileged user*, which requires more
+configuration of the system.
 
 ## Getting started
 
-see the [getting started doc](docs/getting-started.md) for some of the basics of configuring your JupyterHub deployment.
+See the [getting started document](docs/source/getting-started.md) for some of the
+basics of configuring your JupyterHub deployment.
 
 ### Some examples
 
-generate a default config file:
+Generate a default config file:
 
     jupyterhub --generate-config
 
-spawn the server on 10.0.1.2:443 with https:
+Spawn the server on ``10.0.1.2:443`` with **https**:
 
     jupyterhub --ip 10.0.1.2 --port 443 --ssl-key my_ssl.key --ssl-cert my_ssl.cert
 
@@ -111,7 +115,7 @@ which should allow plugging into a variety of authentication or process control 
 Some examples, meant as illustration and testing of this concept:
 
 - Using GitHub OAuth instead of PAM with [OAuthenticator](https://github.com/jupyter/oauthenticator)
-- Spawning single-user servers with docker, using the [DockerSpawner](https://github.com/jupyter/dockerspawner)
+- Spawning single-user servers with Docker, using the [DockerSpawner](https://github.com/jupyter/dockerspawner)
 
 # Getting help
 
@@ -119,6 +123,13 @@ We encourage you to ask questions on the mailing list:
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
 
-but you can participate in development discussions or get live help on Gitter:
+and you may participate in development discussions or get live help on Gitter:
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jupyter/jupyterhub?utm_source=badge&utm_medium=badge)
+
+## Resources
+- [Project Jupyter website](https://jupyter.org)
+- [Documentation for JupyterHub](http://jupyterhub.readthedocs.org/en/latest/) [[PDF](https://media.readthedocs.org/pdf/jupyterhub/latest/jupyterhub.pdf)]
+- [Documentation for Project Jupyter](http://jupyter.readthedocs.org/en/latest/index.html) [[PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)]
+- [Issues](https://github.com/jupyter/jupyterhub/issues)
+- [Technical support - Jupyter Google Group](https://groups.google.com/forum/#!forum/jupyter)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Next, install JavaScript dependencies:
 
     sudo npm install -g configurable-http-proxy
 
-### Optional Installation Prerequisite (pip)
+### (Optional) Installation Prerequisite (pip)
 
 Notes on `pip` command used in the below installation sections:
 - `sudo` may be needed for `pip install`, depending on the user's filesystem permissions.


### PR DESCRIPTION
Update README:

* correct links to the docs new location
* use Jupyter in instructions
* added badges for Travis and RTD builds
* added resources section at end (which we have been doing to give users an easy way to get to the Project Jupyter website, issues, and download of current docs
* Updates to grammar and style

In addition, the GitHub repo link in the repo description should be updated to ``https://jupyterhub.readthedocs.org``.