### PR TITLE
If spawner fails to start, show error page

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -296,10 +296,14 @@ class BaseHandler(RequestHandler):
             yield gen.with_timeout(timedelta(seconds=self.slow_spawn_timeout), f)
         except gen.TimeoutError:
             if user.spawn_pending:
-                # hit timeout, but spawn is still pending
-                self.log.warn("User %s server is slow to start", user.name)
-                # schedule finish for when the user finishes spawning
-                IOLoop.current().add_future(f, finish_user_spawn)
+                status = yield user.spawner.poll()
+                if status is None:
+                    # hit timeout, but spawn is still pending
+                    self.log.warn("User %s server is slow to start", user.name)
+                    # schedule finish for when the user finishes spawning
+                    IOLoop.current().add_future(f, finish_user_spawn)
+                else:
+                    raise web.HTTPError(500, "Spawner failed to start [status=%s]" % status)
             else:
                 raise
         else:

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -123,7 +123,7 @@ class Server(Base):
                     if e.errno == errno.ECONNREFUSED:
                         return False
                     else:
-                       	raise
+                        raise
                 else:
                     return True
             elif e.errno == errno.ECONNREFUSED:

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -54,8 +54,8 @@ class SlowSpawner(MockSpawner):
     
     @gen.coroutine
     def start(self):
-        yield gen.sleep(2)
         yield super().start()
+        yield gen.sleep(2)
     
     @gen.coroutine
     def stop(self):
@@ -100,7 +100,9 @@ class MockPAMAuthenticator(PAMAuthenticator):
     def authenticate(self, *args, **kwargs):
         with mock.patch.multiple('pamela',
                 authenticate=mock_authenticate,
-                open_session=mock_open_session):
+                open_session=mock_open_session,
+                close_session=mock_open_session,
+                ):
             return super(MockPAMAuthenticator, self).authenticate(*args, **kwargs)
 
 class MockHub(JupyterHub):

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -85,6 +85,7 @@ class User(HasTraits):
         if self.orm_user:
             id = self.orm_user.id
             self.orm_user = new.query(orm.User).filter(orm.User.id==id).first()
+        self.spawner.db = self.db
     
     orm_user = None
     spawner = None
@@ -177,6 +178,8 @@ class User(HasTraits):
         # wait for spawner.start to return
         try:
             f = spawner.start()
+            # commit any changes in spawner.start (always commit db changes before yield)
+            db.commit()
             yield gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
         except Exception as e:
             if isinstance(e, gen.TimeoutError):


### PR DESCRIPTION
instead of slow-spawner page

and fix a couple of db-sync/race bugs revealed by the change