### PR TITLE
Update documentation link to source code

### DIFF
--- a/docs/source/spawners.md
+++ b/docs/source/spawners.md
@@ -157,4 +157,4 @@ When `Spawner.spawn` is called, this dictionary is accessible as `self.user_opti
 
 
 
-[Spawner]: ../jupyterhub/spawner.py
+[Spawner]: https://github.com/jupyter/jupyterhub/blob/master/jupyterhub/spawner.py


### PR DESCRIPTION
Update link to Spawner source code. I've used an external link to the file on GitHub. 

The relative link does not redirect properly (even when corrected) to the GitHub hosted file. Read The Docs returns not found. Sphinx and RTD will be happier with the external link.

@minrk Nice work on 0.4. 