### PR TITLE
Restore /login handler

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,6 +4,12 @@ See `git log` for a more detailed summary.
 
 ## 0.4
 
+### 0.4.1
+
+Fix removal of `/login` page in 0.4.0, breaking some OAuth providers.
+
+### 0.4.0
+
 - Add `Spawner.user_options_form` for specifying an HTML form to present to users,
   allowing users to influence the spawning of their own servers.
 - Add `Authenticator.pre_spawn_start` and `Authenticator.post_spawn_stop` hooks,

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -86,7 +86,9 @@ class LoginHandler(BaseHandler):
             self.finish(html)
 
 
-# Only logout is a default handler.
+# /login renders the login page or the "Login with..." link,
+# so it should always be registered.
+# /logout clears cookies.
 default_handlers = [
     (r"/login", LoginHandler),
     (r"/logout", LogoutHandler),

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -88,5 +88,6 @@ class LoginHandler(BaseHandler):
 
 # Only logout is a default handler.
 default_handlers = [
+    (r"/login", LoginHandler),
     (r"/logout", LogoutHandler),
 ]


### PR DESCRIPTION
While a custom `login_url` can be used, e.g. for oauth, `/login` is still used for the "Login with ..." confirmation page.