### PR TITLE
require confirmation for JupyterHub to run without SSL

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -2,6 +2,12 @@
 
 See `git log` for a more detailed summary.
 
+## 0.5
+
+- Single-user server must be run with Jupyter Notebook ≥ 4.0
+- Require `--no-ssl` confirmation to allow the Hub to be run without SSL (e.g. behind SSL termination in nginx)
+
+
 ## 0.4
 
 ### 0.4.1

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -109,6 +109,7 @@ class MockHub(JupyterHub):
     """Hub with various mock bits"""
 
     db_file = None
+    confirm_no_ssl = True
     
     def _ip_default(self):
         return localhost()


### PR DESCRIPTION
ensures folks deploying JupyterHub on HTTP have been told what's up.

related: #416

cc @ellisonbg: for those running behind nginx, if we do this, JupyterHub will refuse to start running without SSL unless `--no-ssl` is specified.