### PR TITLE
allow overriding logo

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -42,7 +42,7 @@ here = os.path.dirname(__file__)
 
 import jupyterhub
 from . import handlers, apihandlers
-from .handlers.static import CacheControlStaticFilesHandler
+from .handlers.static import CacheControlStaticFilesHandler, LogoHandler
 
 from . import orm
 from .user import User, UserDict
@@ -238,6 +238,11 @@ class JupyterHub(Application):
     base_url = URLPrefix('/', config=True,
         help="The base URL of the entire application"
     )
+    logo_file = Unicode('', config=True,
+        help="Specify path to a logo image to override the Jupyter logo in the banner."
+    )
+    def _logo_file_default(self):
+        return os.path.join(self.data_files_path, 'static', 'images', 'jupyter.png')
     
     jinja_environment_options = Dict(config=True,
         help="Supply extra arguments that will be passed to Jinja environment."
@@ -483,6 +488,8 @@ class JupyterHub(Application):
         # set default handlers
         h.extend(handlers.default_handlers)
         h.extend(apihandlers.default_handlers)
+        
+        h.append((r'/logo', LogoHandler, {'path': self.logo_file}))
         self.handlers = self.add_url_prefix(self.hub_prefix, h)
         # some extra handlers, outside hub_prefix
         self.handlers.extend([

--- a/jupyterhub/handlers/static.py
+++ b/jupyterhub/handlers/static.py
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import os
 from tornado.web import StaticFileHandler
 
 class CacheControlStaticFilesHandler(StaticFileHandler):
@@ -14,4 +15,14 @@ class CacheControlStaticFilesHandler(StaticFileHandler):
     def set_extra_headers(self, path):
         if "v" not in self.request.arguments:
             self.add_header("Cache-Control", "no-cache")
-    
+
+class LogoHandler(StaticFileHandler):
+    """A singular handler for serving the logo."""
+    def get(self):
+        return super().get('')
+
+    @classmethod
+    def get_absolute_path(cls, root, path):
+        """We only serve one file, ignore relative path"""
+        return os.path.abspath(root)
+

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -147,3 +147,18 @@ def test_spawn_form_with_file(app, io_loop):
                       'content_type': 'application/unknown'},
         }
 
+
+def test_static_files(app):
+    base_url = ujoin(app.proxy.public_server.url, app.hub.server.base_url)
+    print(base_url)
+    r = requests.get(ujoin(base_url, 'logo'))
+    r.raise_for_status()
+    assert r.headers['content-type'] == 'image/png'
+    r = requests.get(ujoin(base_url, 'static', 'images', 'jupyter.png'))
+    r.raise_for_status()
+    assert r.headers['content-type'] == 'image/png'
+    r = requests.get(ujoin(base_url, 'static', 'css', 'style.min.css'))
+    r.raise_for_status()
+    assert r.headers['content-type'] == 'text/css'
+
+     

--- a/scripts/jupyterhub-singleuser
+++ b/scripts/jupyterhub-singleuser
@@ -129,6 +129,9 @@ page_template = """
 >
 Control Panel</a>
 {% endblock %}
+{% block logo %}
+<img src='{{logo_url}}' alt='Jupyter Notebook'/>
+{% endblock logo %}
 """
 
 class SingleUserNotebookApp(NotebookApp):
@@ -200,6 +203,8 @@ class SingleUserNotebookApp(NotebookApp):
     
     def patch_templates(self):
         """Patch page templates to add Hub-related buttons"""
+        
+        self.jinja_template_vars['logo_url'] = url_path_join(self.hub_prefix, 'logo')
         env = self.web_app.settings['jinja2_env']
         
         env.globals['hub_control_panel_url'] = \

--- a/share/jupyter/hub/templates/page.html
+++ b/share/jupyter/hub/templates/page.html
@@ -82,7 +82,7 @@
 
 <div id="header" class="navbar navbar-static-top">
   <div class="container">
-  <span id="jupyterhub-logo" class="pull-left"><a href="{{base_url}}"><img src='{{static_url("images/jupyter.png") }}' alt='JupyterHub' class='jpy-logo' title='Home'/></a></span>
+  <span id="jupyterhub-logo" class="pull-left"><a href="{{base_url}}"><img src='{{base_url}}logo' alt='JupyterHub' class='jpy-logo' title='Home'/></a></span>
 
   {% block login_widget %}
 


### PR DESCRIPTION
by specifying path in JupyterHub.logo_file

also ensures single-user server always has the same logo image as the Hub

closes #418