### PR TITLE
disable port_retries in single-user server

### DIFF
--- a/scripts/jupyterhub-singleuser
+++ b/scripts/jupyterhub-singleuser
@@ -147,6 +147,7 @@ class SingleUserNotebookApp(NotebookApp):
     trust_xheaders = True
     login_handler_class = JupyterHubLoginHandler
     logout_handler_class = JupyterHubLogoutHandler
+    port_retries = 0 # disable port-retries, since the Spawner will tell us what port to use
 
     cookie_cache_lifetime = Integer(
         config=True,


### PR DESCRIPTION
Since Spawners won't notice that the server has started somewhere other than where it was asked to, it should fail outright.