### PR TITLE
add debug logging for adding users with no running server

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -228,8 +228,13 @@ class Proxy(Base):
         futures = []
         db = inspect(self).session
         for user in db.query(User).filter(User.server != None):
+            if user.server is None:
+                # This should never be True, but seems to be on rare occasion.
+                # catch filter bug, either in sqlalchemy or my understanding of its behavior
+                self.log.error("User %s has no server, but wasn't filtered out.", user)
+                continue
             if user.name not in have_routes:
-                self.log.warn("Adding missing route for %s", user.name)
+                self.log.warning("Adding missing route for %s (%s)", user.name, user.server)
                 futures.append(self.add_user(user))
         for f in futures:
             yield f


### PR DESCRIPTION
in check_routes, it has been reported that users without a running server are attempted to be added.

So something is wrong, either in sqlalchemy or my understanding of what it does (likely the latter), because [this filter]([this line](https://github.com/jupyter/jupyterhub/blob/0.4.1/jupyterhub/orm.py#L230)) for users with a non-None server is returning at least one result whose server is None [here](https://github.com/jupyter/jupyterhub/blob/0.4.1/jupyterhub/orm.py#L233).