### PR TITLE
Do not consider `@` character url-safe

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -146,7 +146,7 @@ class User(HasTraits):
     @property
     def escaped_name(self):
         """My name, escaped for use in URLs, cookies, etc."""
-        return quote(self.name, safe='@')
+        return quote(self.name, safe='')
     
     @gen.coroutine
     def spawn(self, options=None):


### PR DESCRIPTION
Usernames that have an `@`-separated domain component
break JupyterHub when the server expects to see query
strings that contain an `@`, when browsers and other
clients send `%40`.