### PR TITLE
Revert "Do not consider `@` character url-safe"

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -146,7 +146,7 @@ class User(HasTraits):
     @property
     def escaped_name(self):
         """My name, escaped for use in URLs, cookies, etc."""
-        return quote(self.name, safe='')
+        return quote(self.name, safe='@')
     
     @gen.coroutine
     def spawn(self, options=None):


### PR DESCRIPTION
Reverts jupyter/jupyterhub#440

@ is safe when using notebook ≥ 4.1

Not to merge, until resolving some discussion in #440 if there's more to it than outdated notebook versions.