### PR TITLE
avoid calling Spawner.poll during Spawner.start

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -206,6 +206,7 @@ class User(HasTraits):
         self.state = spawner.get_state()
         self.last_activity = datetime.utcnow()
         db.commit()
+        self.spawn_pending = False
         try:
             yield self.server.wait_up(http=True, timeout=spawner.http_timeout)
         except Exception as e:
@@ -232,7 +233,6 @@ class User(HasTraits):
                 ), exc_info=True)
             # raise original TimeoutError
             raise e
-        self.spawn_pending = False
         return self
 
     @gen.coroutine


### PR DESCRIPTION
moves `spawn_pending` flag to only around start, not the HTTP wait.

Some Spawners may not know how to poll until start has finished (DockerSpawner). Let's not require that they do.

cc @betatim

https://github.com/jupyter/dockerspawner/pull/73

closes #428