### PR TITLE
Don't add users with spawn_pending to the proxy

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -145,6 +145,8 @@ class User(HasTraits):
     @property
     def running(self):
         """property for whether a user has a running server"""
+        if self.spawn_pending:
+            return False # server is not running if spawn is still pending
         if self.server is None:
             return False
         return True


### PR DESCRIPTION
`check_routes` checks for missing routes for running users. This is meant for when the proxy has been relaunched outside the Hub.

If spawners are slow to start, it's possible for check_routes to fire in the middle of spawning, triggering addition of the user's server (which has no defined location yet) to the proxy before it's up. Further, if the spawning fails, the route will remain indefinitely (because it never should have been added in the first place), and the user will see 503 until their server is launched manually again.

Checking `spawn_pending` in user.running prevents this.

closes #410