### PR TITLE
Redirect requests to logged in user

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -461,6 +461,7 @@ class UserSpawnHandler(BaseHandler):
     redirect her to /user/alice/notebooks/mynotebook.ipynb, which should
     in turn call this function.
     """
+
     @gen.coroutine
     def get(self, name, user_path):
         current_user = self.get_current_user()
@@ -488,11 +489,18 @@ class UserSpawnHandler(BaseHandler):
             if self.use_subdomains:
                 target = current_user.host + target
             self.redirect(target)
-        else:
+        elif current_user:
             # logged in as a different user, redirect
             target = url_path_join(self.base_url, 'user', current_user.name,
                                    user_path or '')
             self.redirect(target)
+        else:
+            # not logged in, clear any cookies and reload
+            self.clear_login_cookie()
+            self.redirect(url_concat(
+                self.settings['login_url'],
+                {'next': self.request.uri},
+            ))
 
 
 class CSPReportHandler(BaseHandler):

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -1,6 +1,6 @@
 """Tests for HTML pages"""
 
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import requests
 
@@ -164,6 +164,14 @@ def test_user_redirect(app):
     print(urlparse(r.url))
     path = urlparse(r.url).path
     assert path == '/user/%s/test.ipynb' % name
+
+    r = get_page('/user/baduser/test.ipynb', app)
+    r.raise_for_status()
+    print(urlparse(r.url))
+    path = urlparse(r.url).path
+    assert path == '/hub/login'
+    query = urlparse(r.url).query
+    assert query == urlencode({'next': '/hub/user/baduser/test.ipynb'})
 
 
 def test_static_files(app):

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -149,6 +149,23 @@ def test_spawn_form_with_file(app, io_loop):
         }
 
 
+def test_user_redirect(app):
+    name = 'wash'
+    cookies = app.login_user(name)
+
+    r = get_page('/user/baduser', app, cookies=cookies)
+    r.raise_for_status()
+    print(urlparse(r.url))
+    path = urlparse(r.url).path
+    assert path == '/user/%s' % name
+
+    r = get_page('/user/baduser/test.ipynb', app, cookies=cookies)
+    r.raise_for_status()
+    print(urlparse(r.url))
+    path = urlparse(r.url).path
+    assert path == '/user/%s/test.ipynb' % name
+
+
 def test_static_files(app):
     base_url = ujoin(public_url(app), app.hub.server.base_url)
     print(base_url)


### PR DESCRIPTION
If a user, alice, requests /user/bob/notebooks/mynotebook.ipynb,
redirect her to /user/alice/notebooks/mynotebook.ipynb.
Currently, such requests get stuck in a redirect loop because
the request will be redirected to login page with a next parameter
that when followed is again redirected.

When notebook_dir is consistent across users, this will allow
users to share notebook URLs. Fixes #424.