### PR TITLE
Use latest version of Sphinx to fix RTD "Edit on GitHub"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 -r ../requirements.txt
-sphinx
+sphinx>=1.3.6
 recommonmark==0.4.0


### PR DESCRIPTION
This PR fixes the issue found by @parente where RTD's "Edit on GitHub" was not correctly redirecting to markdown source and throwing a 404 instead. The cause was an underlying bug in Sphinx which has been fixed as 1.3.6.

I've updated our version of Sphinx to 1.3.6 or greater.