### PR TITLE
Add additional documentation on --no-SSL option

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -22,9 +22,12 @@ There are three main categories of processes run by the `jupyterhub` command lin
 
 ## JupyterHub's default behavior
 
-**IMPORTANT:** In its default configuration, JupyterHub runs without SSL encryption (HTTPS).
+**IMPORTANT:** In its default configuration, JupyterHub requires SSL encryption (HTTPS) to run.
 **You should not run JupyterHub without SSL encryption on a public network.**
-See [Security documentation](#Security) for how to configure JupyterHub to use SSL.
+See [Security documentation](#Security) for how to configure JupyterHub to use SSL and, in
+certain cases, e.g. behind SSL termination in nginx, allowing no SSL on the hub
+by requiring `--no-ssl` confirmation to allow the Hub to be run without SSL
+as of [version 5.0](./changelog.html).
 
 To start JupyterHub in its default configuration, type the following at the command line:
 
@@ -147,7 +150,7 @@ c.JupyterHub.hub_port = 54321
 
 ## Security
 
-**IMPORTANT:** In its default configuration, JupyterHub runs without SSL encryption (HTTPS).
+**IMPORTANT:** In its default configuration, JupyterHub requires SSL encryption (HTTPS) to run.
 **You should not run JupyterHub without SSL encryption on a public network.**
 
 Security is the most important aspect of configuring Jupyter. There are three main aspects of the
@@ -180,6 +183,10 @@ c.JupyterHub.ssl_cert = '/etc/letsencrypt/live/your.domain.com/fullchain.pem'
 Some cert files also contain the key, in which case only the cert is needed. It is important that
 these files be put in a secure location on your server, where they are not readable by regular
 users.
+
+Note: In certain cases, e.g. behind SSL termination in nginx, allowing no SSL 
+running on the hub may be desired. To run the Hub without SSL, you must opt
+in by configuring and confirming the `--no-ssl` option, added as of [version 5.0](./changelog.html).
 
 ## Cookie secret
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -24,10 +24,9 @@ There are three main categories of processes run by the `jupyterhub` command lin
 
 **IMPORTANT:** In its default configuration, JupyterHub requires SSL encryption (HTTPS) to run.
 **You should not run JupyterHub without SSL encryption on a public network.**
-See [Security documentation](#Security) for how to configure JupyterHub to use SSL and, in
-certain cases, e.g. behind SSL termination in nginx, allowing no SSL on the hub
-by requiring `--no-ssl` confirmation to allow the Hub to be run without SSL
-as of [version 5.0](./changelog.html).
+See [Security documentation](#Security) for how to configure JupyterHub to use SSL, and in
+certain cases, e.g. behind SSL termination in nginx, allowing the hub to run with no SSL
+by requiring `--no-ssl` (as of [version 5.0](./changelog.html)).
 
 To start JupyterHub in its default configuration, type the following at the command line:
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -26,7 +26,7 @@ There are three main categories of processes run by the `jupyterhub` command lin
 **You should not run JupyterHub without SSL encryption on a public network.**
 See [Security documentation](#Security) for how to configure JupyterHub to use SSL, and in
 certain cases, e.g. behind SSL termination in nginx, allowing the hub to run with no SSL
-by requiring `--no-ssl` (as of [version 5.0](./changelog.html)).
+by requiring `--no-ssl` (as of [version 0.5](./changelog.html)).
 
 To start JupyterHub in its default configuration, type the following at the command line:
 
@@ -185,7 +185,7 @@ users.
 
 Note: In certain cases, e.g. behind SSL termination in nginx, allowing no SSL 
 running on the hub may be desired. To run the Hub without SSL, you must opt
-in by configuring and confirming the `--no-ssl` option, added as of [version 5.0](./changelog.html).
+in by configuring and confirming the `--no-ssl` option, added as of [version 0.5](./changelog.html).
 
 ## Cookie secret
 


### PR DESCRIPTION
Closes #419 

Revises two sections in the documentation to reflect the change in v0.5.