### PR TITLE
Allow environment config values to be callable

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -220,10 +220,17 @@ class Spawner(LoggingConfigurable):
         for key in self.env_keep:
             if key in os.environ:
                 env[key] = os.environ[key]
-        
-        # config overrides
-        env.update(self.environment)
-        
+
+        # config overrides. If the value is a callable, it will be called with
+        # one parameter - the current spawner instance - and the return value
+        # will be assigned to the environment variable. This will be called at
+        # spawn time.
+        for key, value in self.environment.items():
+            if callable(value):
+                env[key] = value(self)
+            else:
+                env[key] = value
+
         env['JPY_API_TOKEN'] = self.api_token
         return env
     

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -123,7 +123,13 @@ class Spawner(LoggingConfigurable):
     """)
     
     environment = Dict(
-        help="Environment variables to load for the Spawner."
+        help="""Environment variables to load for the Spawner.
+
+        Value could be a string or a callable. If it is a callable, it will
+        be called with one parameter, which will be the instance of the spawner
+        in use. It should quickly (without doing much blocking operations) return
+        a string that will be used as the value for the environment variable.
+        """
     ).tag(config=True)
     
     cmd = Command(['jupyterhub-singleuser'],


### PR DESCRIPTION
This allows deployments to configure environment variables
that need to be different for each user / container (such as
credentials for various services, etc).