### PR TITLE
Use User.url instead of constructing it manually

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -492,8 +492,7 @@ class UserSpawnHandler(BaseHandler):
             self.redirect(target)
         elif current_user:
             # logged in as a different user, redirect
-            target = url_path_join(self.base_url, 'user', current_user.name,
-                                   user_path or '')
+            target = url_path_join(current_user.url, user_path or '')
             self.redirect(target)
         else:
             # not logged in, clear any cookies and reload


### PR DESCRIPTION
This fixes issues with URL encoding when redirecting users to
their own notebook instances