### PR TITLE
disable npm progress when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ class Bower(BaseCommand):
         
         if self.should_run_npm():
             print("installing build dependencies with npm")
-            check_call(['npm', 'install'], cwd=here)
+            check_call(['npm', 'install', '--progress=false'], cwd=here)
             os.utime(self.node_modules)
         
         env = os.environ.copy()


### PR DESCRIPTION
apparently faster, but should also avoid unicode bugs in pip