### PR TITLE
allow pre-loading API tokens from config

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -303,11 +303,19 @@ class User(Base):
                 name=self.name,
             )
 
-    def new_api_token(self):
-        """Create a new API token"""
+    def new_api_token(self, token=None):
+        """Create a new API token
+        
+        If `token` is given, load that token.
+        """
         assert self.id is not None
         db = inspect(self).session
-        token = new_token()
+        if token is None:
+            token = new_token()
+        else:
+            found = APIToken.find(db, token)
+            if found:
+                raise ValueError("Collision on token: %s..." % token[:4])
         orm_token = APIToken(user_id=self.id)
         orm_token.token = token
         db.add(orm_token)

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -313,6 +313,8 @@ class User(Base):
         if token is None:
             token = new_token()
         else:
+            if len(token) < 8:
+                raise ValueError("Tokens must be at least 8 characters, got %r" % token)
             found = APIToken.find(db, token)
             if found:
                 raise ValueError("Collision on token: %s..." % token[:4])

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -93,6 +93,16 @@ def test_tokens(db):
     found = orm.APIToken.find(db, 'something else')
     assert found is None
 
+    secret = 'super-secret-preload-token'
+    token = user.new_api_token(secret)
+    assert token == secret
+    assert len(user.api_tokens) == 3
+
+    # raise ValueError on collision
+    with pytest.raises(ValueError):
+        user.new_api_token(token)
+    assert len(user.api_tokens) == 3
+
 
 def test_spawn_fails(db, io_loop):
     orm_user = orm.User(name='aeofel')


### PR DESCRIPTION
This is the first small part of easing the pain of jupyterhub-associated services, so you shouldn't need to initialize JupyterHub before setting API tokens for services that need API access to the Hub.

cc @jhamrick, who I know has suffered from the need to generate tokens with `jupyterhub token`.