### PR TITLE
cookie_secret file must be base64

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -97,7 +97,7 @@ for the full command line help.
 
 All configurable options are technically configurable on the command-line,
 even if some are really inconvenient to type. Just replace the desired option,
-c.Class.trait, with --Class.trait. For example, to configure 
+c.Class.trait, with --Class.trait. For example, to configure
 c.Spawner.notebook_dir = '~/assignments' from the command-line:
 
     jupyterhub --Spawner.notebook_dir='~/assignments'
@@ -190,7 +190,7 @@ Some cert files also contain the key, in which case only the cert is needed. It 
 these files be put in a secure location on your server, where they are not readable by regular
 users.
 
-Note: In certain cases, e.g. behind SSL termination in nginx, allowing no SSL 
+Note: In certain cases, e.g. behind SSL termination in nginx, allowing no SSL
 running on the hub may be desired. To run the Hub without SSL, you must opt
 in by configuring and confirming the `--no-ssl` option, added as of [version 0.5](./changelog.html).
 
@@ -205,26 +205,36 @@ as follows:
 c.JupyterHub.cookie_secret_file = '/srv/jupyterhub/cookie_secret'
 ```
 
-The content of this file should be a long random string. An example would be to generate this
-file as:
+The content of this file should be a long random string encoded in MIME Base64. An example would be to generate thisfile as:
 
 ```bash
-openssl rand -hex 1024 > /srv/jupyterhub/cookie_secret
+openssl rand -base64 2048 > /srv/jupyterhub/cookie_secret
 ```
 
 In most deployments of JupyterHub, you should point this to a secure location on the file
 system, such as `/srv/jupyterhub/cookie_secret`. If the cookie secret file doesn't exist when
-the Hub starts, a new cookie secret is generated and stored in the file. The recommended
-permissions for the cookie secret file should be 600 (owner-only rw).
+the Hub starts, a new cookie secret is generated and stored in the file. The
+file must not be readable by group or other or the server won't start.
+The recommended -permissions for the cookie secret file should be 600 (owner-only rw).
+
 
 If you would like to avoid the need for files, the value can be loaded in the Hub process from
-the `JPY_COOKIE_SECRET` environment variable:
+the `JPY_COOKIE_SECRET` environment variable, which is a hex-encoded string. You
+can set it this way:
 
 ```bash
 export JPY_COOKIE_SECRET=`openssl rand -hex 1024`
 ```
 
 For security reasons, this environment variable should only be visible to the Hub.
+If you set it dynamically as above, all users will be logged out each time the
+Hub starts.
+
+You can also set the secret in the configuration file itself as a binary string:
+
+```python
+c.JupyterHub.cookie_secret = bytes.fromhex('VERY LONG SECRET HEX STRING')
+```
 
 ## Proxy authentication token
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -610,23 +610,27 @@ class JupyterHub(Application):
         secret = self.cookie_secret
         secret_from = 'config'
         # load priority: 1. config, 2. env, 3. file
-        if not secret and os.environ.get(env_name):
+        secret_env = os.environ.get(env_name)
+        if not secret and secret_env:
             secret_from = 'env'
             self.log.info("Loading %s from env[%s]", trait_name, env_name)
-            secret = binascii.a2b_hex(os.environ[env_name])
+            secret = binascii.a2b_hex(secret_env)
         if not secret and os.path.exists(secret_file):
             secret_from = 'file'
-            perm = os.stat(secret_file).st_mode
-            if perm & 0o07:
-                self.log.error("Bad permissions on %s", secret_file)
-            else:
-                self.log.info("Loading %s from %s", trait_name, secret_file)
+            self.log.info("Loading %s from %s", trait_name, secret_file)
+            try:
+                perm = os.stat(secret_file).st_mode
+                assert not perm & 0o07, \
+                    "cookie_secret_file can be read or written by anybody"
                 with open(secret_file) as f:
                     b64_secret = f.read()
-                try:
-                    secret = binascii.a2b_base64(b64_secret)
-                except Exception as e:
-                    self.log.error("%s does not contain b64 key: %s", secret_file, e)
+                secret = binascii.a2b_base64(b64_secret)
+            except Exception as e:
+                self.log.error(
+                    'Refusing to run JuptyterHub with invalid cookie_secret_file.',
+                    '%s error was: %s',
+                    secret_file, e)
+                sys.exit(1)
         if not secret:
             secret_from = 'new'
             self.log.debug("Generating new %s", trait_name)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -352,10 +352,10 @@ class JupyterHub(Application):
     cookie_secret_file = Unicode('jupyterhub_cookie_secret',
         help="""File in which to store the cookie secret."""
     ).tag(config=True)
-    
+
     api_tokens = Dict(Unicode(),
         help="""Dict of token:username to be loaded into the database.
-        
+
         Allows ahead-of-time generation of API tokens for use by services.
         """
     ).tag(config=True)
@@ -617,7 +617,7 @@ class JupyterHub(Application):
         if not secret and os.path.exists(secret_file):
             secret_from = 'file'
             perm = os.stat(secret_file).st_mode
-            if perm & 0o077:
+            if perm & 0o07:
                 self.log.error("Bad permissions on %s", secret_file)
             else:
                 self.log.info("Loading %s from %s", trait_name, secret_file)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -627,8 +627,8 @@ class JupyterHub(Application):
                 secret = binascii.a2b_base64(b64_secret)
             except Exception as e:
                 self.log.error(
-                    'Refusing to run JuptyterHub with invalid cookie_secret_file.',
-                    '%s error was: %s',
+                    "Refusing to run JuptyterHub with invalid cookie_secret_file. "
+                    "%s error was: %s",
                     secret_file, e)
                 sys.exit(1)
         if not secret:


### PR DESCRIPTION
cookie_secret file is decoded by binascii.a2b_base64 so need to document it must be Base64. 

Added better doc for other values, and included description of "cookie_secret" parameter as well.

A couple of lines had trailing spaces, which my editor automatically deleted.